### PR TITLE
Split cwl.py into two files, one with run_workflow() and one with the…

### DIFF
--- a/fairworkflows/cwl.py
+++ b/fairworkflows/cwl.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import logging
 import tempfile
@@ -15,7 +16,7 @@ from .exceptions import CWLException
 _logger = logging.getLogger(__name__)
 
 DEFAULT_TYPE = 'int'
-
+PROVENANCE = 'provenance'
 
 def create_workflow(name, steps, project_dir):
     # TODO: Right now all steps will be brand new. In the future it should be possible to specify existing steps
@@ -85,7 +86,7 @@ def run_workflow(wf_path: Union[Path, str], inputs: Dict[str, any], output_dir: 
     if output_dir is None:
         output_dir = Path(tempfile.mkdtemp())
     log_path = str(output_dir / 'log.txt')
-    output_dir = str(output_dir)
+    prov_dir = output_dir / PROVENANCE
 
     wf_path = str(wf_path)
 
@@ -93,13 +94,14 @@ def run_workflow(wf_path: Union[Path, str], inputs: Dict[str, any], output_dir: 
 
     cwltool_args = []
 
-    if output_dir:
-        cwltool_args += ['--outdir', str(output_dir)]
-
     if base_dir:
         cwltool_args += ['--basedir', str(base_dir)]
 
     cwltool_args += ['--logFile', str(log_path)]
+    cwltool_args += ['--outdir', str(output_dir)]
+
+    # RO Crate containing provenance will be stored in a "provenance" subdirectory
+    cwltool_args += ['--provenance', str(prov_dir)]
 
     try:
         cwltoil.main(cwltool_args + [wf_path] + wf_input)

--- a/fairworkflows/cwl.py
+++ b/fairworkflows/cwl.py
@@ -1,81 +1,15 @@
-import os
-import argparse
 import logging
 import tempfile
 from pathlib import Path
 from typing import List, Union, Dict, Optional
 import tempfile
 
-import cwlgen
-from scriptcwl import WorkflowGenerator
-from toil.cwl import cwltoil
-
-from config import CWL_WORKFLOW_DIR, CWL_STEPS_DIR, CWL_DIR
 from .exceptions import CWLException
 
 _logger = logging.getLogger(__name__)
 
 DEFAULT_TYPE = 'int'
 PROVENANCE = 'provenance'
-
-def create_workflow(name, steps, project_dir):
-    # TODO: Right now all steps will be brand new. In the future it should be possible to specify existing steps
-    project_dir = Path(project_dir)
-    cwl_path = project_dir / CWL_DIR
-    steps_path = project_dir / CWL_STEPS_DIR
-    workflow_path = project_dir / CWL_WORKFLOW_DIR
-
-    cwl_path.mkdir(exist_ok=True)
-    steps_path.mkdir(exist_ok=True)
-    workflow_path.mkdir(exist_ok=True)
-
-    # Create commandlinetool for every step
-    for step in steps:
-        tool_object = create_commandlinetool(step)
-        tool_object.export(steps_path / f'{step["name"]}.cwl')
-
-    with WorkflowGenerator() as wf:
-        wf.load(steps_path)
-
-        # TODO: Replace use of default type with actual specified type
-        # Input to the first step is the input to the workflow
-        first_step = steps[0]
-        inputs = {f'{first_step["name"]}/{name}': wf.add_input(**{name: DEFAULT_TYPE}) for name in first_step['input']}
-
-        # Add first defined step. We don't have the information on how separate step inputs and outputs are linked so we
-        # can't yet add all steps.
-        step_func = wf.__getattr__(first_step['name'])
-        inputs = step_func(**inputs)
-        wf.add_outputs()
-
-        # TODO: Add functionality to link multiple steps
-
-        filepath = workflow_path / f'{name}.cwl'
-
-        wf.save(filepath)
-
-        return filepath
-
-
-def create_commandlinetool(step: Dict[str, Union[str, List]]) -> cwlgen.CommandLineTool:
-    name = step['name']
-    description = step['description']
-
-    # Initialize commandlinetool
-    # TODO: Specify path
-    tool_object = cwlgen.CommandLineTool(tool_id=name,
-                                         base_command=f"./{name}.py",
-                                         doc=description,
-                                         cwl_version="v1.0")
-
-    # Specify input parameters
-    tool_object.inputs += [cwlgen.CommandInputParameter(p, param_type=DEFAULT_TYPE) for p in step['input']]
-
-    # Specify output parameters
-    tool_object.outputs += [cwlgen.CommandInputParameter(p, param_type=DEFAULT_TYPE) for p in step['output']]
-
-    return tool_object
-
 
 def run_workflow(wf_path: Union[Path, str], inputs: Dict[str, any], output_dir: Optional[Union[Path, str]] = None,
                  base_dir=None):
@@ -114,10 +48,3 @@ def run_workflow(wf_path: Union[Path, str], inputs: Dict[str, any], output_dir: 
         runlogs = infile.read()
 
     return output_dir, runlogs
-
-
-def _create_cwl_args(d: Dict[any, any]):
-    # Convert dict arguments to what they would look like as command line arguments.
-    args = [f'--{k}={v}' for k, v in d.items()]
-
-    return argparse.ArgumentParser().parse_args(args)

--- a/fairworkflows/cwl.py
+++ b/fairworkflows/cwl.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Union, Dict, Optional
 import tempfile
+from toil.cwl import cwltoil
 
 from .exceptions import CWLException
 

--- a/fairworkflows/cwl_cli.py
+++ b/fairworkflows/cwl_cli.py
@@ -6,7 +6,6 @@ from typing import List, Union, Dict, Optional
 import tempfile
 
 import cwlgen
-import cwltool.main as cwltool_main
 from scriptcwl import WorkflowGenerator
 
 from config import CWL_WORKFLOW_DIR, CWL_STEPS_DIR, CWL_DIR

--- a/fairworkflows/cwl_cli.py
+++ b/fairworkflows/cwl_cli.py
@@ -1,0 +1,83 @@
+import argparse
+import logging
+from io import StringIO
+from pathlib import Path
+from typing import List, Union, Dict, Optional
+import tempfile
+
+import cwlgen
+import cwltool.main as cwltool_main
+from scriptcwl import WorkflowGenerator
+
+from config import CWL_WORKFLOW_DIR, CWL_STEPS_DIR, CWL_DIR
+from .exceptions import CWLException
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_TYPE = 'int'
+
+
+def create_workflow(name, steps, project_dir):
+    # TODO: Right now all steps will be brand new. In the future it should be possible to specify existing steps
+    project_dir = Path(project_dir)
+    cwl_path = project_dir / CWL_DIR
+    steps_path = project_dir / CWL_STEPS_DIR
+    workflow_path = project_dir / CWL_WORKFLOW_DIR
+
+    cwl_path.mkdir(exist_ok=True)
+    steps_path.mkdir(exist_ok=True)
+    workflow_path.mkdir(exist_ok=True)
+
+    # Create commandlinetool for every step
+    for step in steps:
+        tool_object = create_commandlinetool(step)
+        tool_object.export(steps_path / f'{step["name"]}.cwl')
+
+    with WorkflowGenerator() as wf:
+        wf.load(steps_path)
+
+        # TODO: Replace use of default type with actual specified type
+        # Input to the first step is the input to the workflow
+        first_step = steps[0]
+        inputs = {f'{first_step["name"]}/{name}': wf.add_input(**{name: DEFAULT_TYPE}) for name in first_step['input']}
+
+        # Add first defined step. We don't have the information on how separate step inputs and outputs are linked so we
+        # can't yet add all steps.
+        step_func = wf.__getattr__(first_step['name'])
+        inputs = step_func(**inputs)
+        wf.add_outputs()
+
+        # TODO: Add functionality to link multiple steps
+
+        filepath = workflow_path / f'{name}.cwl'
+
+        wf.save(filepath)
+
+        return filepath
+
+
+def create_commandlinetool(step: Dict[str, Union[str, List]]) -> cwlgen.CommandLineTool:
+    name = step['name']
+    description = step['description']
+
+    # Initialize commandlinetool
+    # TODO: Specify path
+    tool_object = cwlgen.CommandLineTool(tool_id=name,
+                                         base_command=f"./{name}.py",
+                                         doc=description,
+                                         cwl_version="v1.0")
+
+    # Specify input parameters
+    tool_object.inputs += [cwlgen.CommandInputParameter(p, param_type=DEFAULT_TYPE) for p in step['input']]
+
+    # Specify output parameters
+    tool_object.outputs += [cwlgen.CommandInputParameter(p, param_type=DEFAULT_TYPE) for p in step['output']]
+
+    return tool_object
+
+
+def _create_cwl_args(d: Dict[any, any]):
+    # Convert dict arguments to what they would look like as command line arguments.
+    args = [f'--{k}={v}' for k, v in d.items()]
+
+    return argparse.ArgumentParser().parse_args(args)

--- a/fairworkflows/workflow.py
+++ b/fairworkflows/workflow.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Dict, Union
 from config import PYTHON_DIR, PLEX_DIR, CWL_DIR
-from . import rdf, pythongen, cwl, nanopub
+from . import rdf, pythongen, cwl_cli, nanopub
 
 
 # TODO: Per input and output the type should be defined
@@ -29,7 +29,7 @@ def process_workflow(name: str, steps: List[Dict[str, Union[str, List[str]]]], t
 
     pythongen.render_python_workflow(steps, workflow_dir)
     rdf.create_plex_workflow(name, steps, workflow_dir)
-    cwl.create_workflow(name, steps, workflow_dir)
+    cwl_cli.create_workflow(name, steps, workflow_dir)
 
 
 def _create_plex_workflow(name, steps):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Jinja2
 rdflib<4.3.0,>=4.2.2
 pytest
 scriptcwl
-cwltool
+cwltool==2.0.20200312183052
 cwlgen
 pyyaml
 requests

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 from config import TESTS_RESOURCES
-from fairworkflows import cwl
+from fairworkflows import cwl, cwl_cli
 from fairworkflows.exceptions import CWLException
 
 SAMPLE_CWL_TOOL = TESTS_RESOURCES / 'test_flow.cwl'

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -56,3 +56,11 @@ def test_run_workflow_produces_result(tmp_path):
 def test_missing_mandatory_input_raises_exception():
     with pytest.raises(CWLException):
         cwl.run_workflow(SAMPLE_CWL_TOOL, {})
+
+
+def test_run_workflow_produces_provenance(tmp_path):
+    cwl.run_workflow(SAMPLE_CWL_TOOL, {'message': 'Provenance will be recorded for this'}, output_dir=tmp_path)
+    prov_path = tmp_path/'provenance'
+
+    assert prov_path.exists()
+    assert len(list(prov_path.iterdir())) > 0

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 from config import TESTS_RESOURCES
-from fairworkflows import cwl
+from fairworkflows import cwl, cwl_cli
 from fairworkflows.exceptions import CWLException
 
 SAMPLE_CWL_TOOL = TESTS_RESOURCES / 'test_flow.cwl'
@@ -19,7 +19,7 @@ WORKFLOW_NAME = 'test_workflow'
 
 
 def test_sample_step_generates_sample_commandlinetool():
-    tool_dict = cwl.create_commandlinetool(SAMPLE_STEP).get_dict()
+    tool_dict = cwl_cli.create_commandlinetool(SAMPLE_STEP).get_dict()
 
     target = {'cwlVersion': 'v1.0', 'id': 'step1',
               'inputs': [{'id': 'sample_input1', 'type': 'int'},
@@ -37,7 +37,7 @@ def test_sample_workflow_has_one_step(tmp_path):
     if not project_dir.exists():
         project_dir.mkdir()
 
-    result_path = cwl.create_workflow(WORKFLOW_NAME, [SAMPLE_STEP], project_dir)
+    result_path = cwl_cli.create_workflow(WORKFLOW_NAME, [SAMPLE_STEP], project_dir)
 
     with result_path.open('r') as f:
         wf = yaml.load(f)

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -5,44 +5,10 @@ from pathlib import Path
 import yaml
 
 from config import TESTS_RESOURCES
-from fairworkflows import cwl, cwl_cli
+from fairworkflows import cwl
 from fairworkflows.exceptions import CWLException
 
 SAMPLE_CWL_TOOL = TESTS_RESOURCES / 'test_flow.cwl'
-
-SAMPLE_STEP = {'name': 'step1',
-               'description': 'description of step 1',
-               'input': ['sample_input1', 'sample_input2'],
-               'output': ['sample_output']}
-
-WORKFLOW_NAME = 'test_workflow'
-
-
-def test_sample_step_generates_sample_commandlinetool():
-    tool_dict = cwl_cli.create_commandlinetool(SAMPLE_STEP).get_dict()
-
-    target = {'cwlVersion': 'v1.0', 'id': 'step1',
-              'inputs': [{'id': 'sample_input1', 'type': 'int'},
-                         {'id': 'sample_input2', 'type': 'int'}],
-              'outputs': [{'id': 'sample_output', 'type': 'int'}],
-              'baseCommand': './step1.py',
-              'doc': 'description of step 1',
-              'class': 'CommandLineTool'}
-
-    assert target == tool_dict
-
-
-def test_sample_workflow_has_one_step(tmp_path):
-    project_dir = Path(tmp_path) / WORKFLOW_NAME
-    if not project_dir.exists():
-        project_dir.mkdir()
-
-    result_path = cwl_cli.create_workflow(WORKFLOW_NAME, [SAMPLE_STEP], project_dir)
-
-    with result_path.open('r') as f:
-        wf = yaml.load(f)
-
-        assert 1 == len(wf['steps'])
 
 
 def test_run_workflow_produces_result(tmp_path):

--- a/tests/test_cwl_cli.py
+++ b/tests/test_cwl_cli.py
@@ -1,0 +1,41 @@
+import pytest
+
+from pathlib import Path
+
+import yaml
+
+from fairworkflows import cwl_cli
+
+SAMPLE_STEP = {'name': 'step1',
+               'description': 'description of step 1',
+               'input': ['sample_input1', 'sample_input2'],
+               'output': ['sample_output']}
+
+WORKFLOW_NAME = 'test_workflow'
+
+
+def test_sample_step_generates_sample_commandlinetool():
+    tool_dict = cwl_cli.create_commandlinetool(SAMPLE_STEP).get_dict()
+
+    target = {'cwlVersion': 'v1.0', 'id': 'step1',
+              'inputs': [{'id': 'sample_input1', 'type': 'int'},
+                         {'id': 'sample_input2', 'type': 'int'}],
+              'outputs': [{'id': 'sample_output', 'type': 'int'}],
+              'baseCommand': './step1.py',
+              'doc': 'description of step 1',
+              'class': 'CommandLineTool'}
+
+    assert target == tool_dict
+
+
+def test_sample_workflow_has_one_step(tmp_path):
+    project_dir = Path(tmp_path) / WORKFLOW_NAME
+    if not project_dir.exists():
+        project_dir.mkdir()
+
+    result_path = cwl_cli.create_workflow(WORKFLOW_NAME, [SAMPLE_STEP], project_dir)
+
+    with result_path.open('r') as f:
+        wf = yaml.load(f)
+
+        assert 1 == len(wf['steps'])


### PR DESCRIPTION
… remaining CLI specific functions. This way cwl.py does not depend on config.py (currently necessary for the jupyter extension to load the lib)