### PR TITLE
Added --enable-dev option to cwl runs

### DIFF
--- a/fairworkflows/cwl.py
+++ b/fairworkflows/cwl.py
@@ -34,6 +34,7 @@ def run_workflow(wf_path: Union[Path, str], inputs: Dict[str, any], output_dir: 
 
     cwltool_args += ['--logFile', str(log_path)]
     cwltool_args += ['--outdir', str(output_dir)]
+    cwltool_args += ['--enable-dev']
 
     # RO Crate containing provenance will be stored in a "provenance" subdirectory
     cwltool_args += ['--provenance', str(prov_dir)]


### PR DESCRIPTION
This will prevent the following error in cwl runs:
```
ValidationException: Version 'v1.2.0-dev1' is a development or deprecated version.
 Update your document to a stable version (v1.0, v1.1) or use --enable-dev to enable support for development and deprecated versions.
```