### PR TITLE
update cwltool version from 2 to 3.0 to fix issue with importing get_listing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ rdflib<4.3.0,>=4.2.2
 flaky
 pytest
 scriptcwl
-cwltool==2.0.20200312183052
+cwltool==3.0.20200807132242
 cwlgen
 pyyaml
 requests


### PR DESCRIPTION
Updated to cwltool 3.0.20200807132242

To fix issue raised when running the JupyterLab/FairWorkflow extension: https://github.com/fair-workflows/FAIRWorkflowsExtension/issues/12