### PR TITLE
Use properties instead of methods for FairWorkflow and FairStep classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ melt_butter = FairStep(uri='http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BB
 arrange_chicken = FairStep(uri='http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M#step', from_nanopub=True)
 
 # Specify ordering of steps
-workflow.set_first_step(preheat_oven)
+workflow.first_step = preheat_oven
 workflow.add(melt_butter, follows=preheat_oven)
 workflow.add(arrange_chicken, follows=melt_butter)
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -108,21 +108,6 @@ class FairStep(RdfWrapper):
         # Specify that step is a ScriptTask
         self._rdf.add((self.this, RDF.type, Nanopub.BPMN.ScriptTask))
 
-
-    @property
-    def rdf(self):
-        """
-            Getter for the rdf graph describing this FairStep.
-        """
-        return self._rdf
-
-    @property
-    def uri(self):
-        """
-            Getter for the URI of this FairStep.
-        """
-        return self._uri
-
     @property
     def is_pplan_step(self):
         """Return True if this FairStep is a pplan:Step, else False."""

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -1,11 +1,10 @@
-from warnings import warn
+import inspect
+from urllib.parse import urldefrag
 
-from .nanopub import Nanopub
 import rdflib
 from rdflib import RDF, DCTERMS
-from urllib.parse import urldefrag
-import inspect
 
+from .nanopub import Nanopub
 from .rdf_wrapper import RdfWrapper
 
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -37,7 +37,7 @@ class FairStep(RdfWrapper):
             else:
                 self._rdf = rdflib.Graph()
 
-        self.this = rdflib.URIRef(self._uri)
+        self.self_ref = rdflib.URIRef(self._uri)
 
 
     def load_from_nanopub(self, uri):
@@ -76,10 +76,10 @@ class FairStep(RdfWrapper):
             step_uri = uri
 
         self._uri = step_uri
-        self.this = rdflib.URIRef(self._uri)
+        self.self_ref = rdflib.URIRef(self._uri)
 
         # Check that the nanopub's assertion actually contains triples refering to the given step's uri
-        if (rdflib.URIRef(self.this), None, None) not in np.assertion:
+        if (rdflib.URIRef(self.self_ref), None, None) not in np.assertion:
             raise ValueError(f'No triples pertaining to the specified step (uri={step_uri}) were found in the assertion graph of the corresponding nanopublication (uri={np_uri})')
 
         # Else extract all triples in the assertion into the rdf graph for this step
@@ -96,31 +96,31 @@ class FairStep(RdfWrapper):
         self._rdf = rdflib.Graph()
         code = inspect.getsource(func)
         self._uri = 'http://purl.org/nanopub/temp/mynanopub#function' + name
-        self.this = rdflib.URIRef(self._uri)
+        self.self_ref = rdflib.URIRef(self._uri)
 
         # Set description of step to the raw function code
         self.description  = code
 
         # Specify that step is a pplan:Step
-        self._rdf.add((self.this, RDF.type, Nanopub.PPLAN.Step))
+        self._rdf.add((self.self_ref, RDF.type, Nanopub.PPLAN.Step))
 
         # Specify that step is a ScriptTask
-        self._rdf.add((self.this, RDF.type, Nanopub.BPMN.ScriptTask))
+        self._rdf.add((self.self_ref, RDF.type, Nanopub.BPMN.ScriptTask))
 
     @property
     def is_pplan_step(self):
         """Return True if this FairStep is a pplan:Step, else False."""
-        return (self.this, RDF.type, Nanopub.PPLAN.Step) in self._rdf
+        return (self.self_ref, RDF.type, Nanopub.PPLAN.Step) in self._rdf
 
     @property
     def is_manual_task(self):
         """Returns True if this FairStep is a bpmn:ManualTask, else False."""
-        return (self.this, RDF.type, Nanopub.BPMN.ManualTask) in self._rdf
+        return (self.self_ref, RDF.type, Nanopub.BPMN.ManualTask) in self._rdf
 
     @property
     def is_script_task(self):
         """Returns True if this FairStep is a bpmn:ScriptTask, else False."""
-        return (self.this, RDF.type, Nanopub.BPMN.ScriptTask) in self._rdf
+        return (self.self_ref, RDF.type, Nanopub.BPMN.ScriptTask) in self._rdf
 
     @property
     def description(self):

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -140,15 +140,12 @@ class FairStep(RdfWrapper):
         """
         self.set_attribute(DCTERMS.description, rdflib.term.Literal(value))
 
-    def validate(self, verbose=True):
-        """
-            Checks whether this step rdf has sufficient information required of
-            a step in the Plex ontology. If not, a message is printed explaining
-            the problem, and the function returns False.
+    def validate(self):
+        """Validate step.
 
-            If verbose is set to False, no explanation messages will be printed.
+        Check whether this step rdf has sufficient information required of
+        a step in the Plex ontology.
         """
-
         conforms = True
         log = ''
 
@@ -164,10 +161,7 @@ class FairStep(RdfWrapper):
             log += 'Step RDF must be either a bpmn:ManualTask or a bpmn:ScriptTask\n'
             conforms = False
 
-        if verbose:
-            print(log)
-
-        return conforms
+        assert conforms, log
 
     def __str__(self):
         """

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -21,6 +21,7 @@ class FairStep(RdfWrapper):
 
     def __init__(self, step_rdf: rdflib.Graph = None, uri=DEFAULT_STEP_URI,
                  from_nanopub=False, func=None):
+        super().__init__(uri=uri)
 
         if func:
             self.from_function(func)
@@ -36,9 +37,6 @@ class FairStep(RdfWrapper):
                     print(f"Warning: Provided URI '{self._uri}' does not match any subject in provided rdf graph.")
             else:
                 self._rdf = rdflib.Graph()
-
-        self.self_ref = rdflib.URIRef(self._uri)
-
 
     def load_from_nanopub(self, uri):
         """

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -4,6 +4,7 @@ from rdflib import RDF, DCTERMS
 from urllib.parse import urldefrag
 import inspect
 
+
 class FairStep:
     """
         Class for building, validating and publishing Fair Steps, as described by the plex ontology in the publication:
@@ -15,7 +16,8 @@ class FairStep:
 
     DEFAULT_STEP_URI = 'http://purl.org/nanopub/temp/mynanopub#step'
 
-    def __init__(self, step_rdf:rdflib.Graph = None, uri = DEFAULT_STEP_URI, from_nanopub=False, func=None):
+    def __init__(self, step_rdf: rdflib.Graph = None, uri=DEFAULT_STEP_URI,
+                 from_nanopub=False, func=None):
 
         if func:
             self.from_function(func)
@@ -73,7 +75,7 @@ class FairStep:
         self._uri = step_uri
         self.this_step = rdflib.URIRef(self._uri)
 
-        # Check that the nanopub's assertion actually contains triples refering to the given step's uri 
+        # Check that the nanopub's assertion actually contains triples refering to the given step's uri
         if (rdflib.URIRef(self.this_step), None, None) not in np.assertion:
             raise ValueError(f'No triples pertaining to the specified step (uri={step_uri}) were found in the assertion graph of the corresponding nanopublication (uri={np_uri})')
 
@@ -124,40 +126,31 @@ class FairStep:
         """
         return self._uri
 
+    @property
     def is_pplan_step(self):
-        """
-            Returns True if this FairStep is a pplan:Step, else False.
-        """
-        if (self.this_step, RDF.type, Nanopub.PPLAN.Step) in self._rdf:
-            return True
-        else:
-            return False
+        """Return True if this FairStep is a pplan:Step, else False."""
+        return (self.this_step, RDF.type, Nanopub.PPLAN.Step) in self._rdf
 
+    @property
     def is_manual_task(self):
-        """
-            Returns True if this FairStep is a bpmn:ManualTask, else False.
-        """
-        if (self.this_step, RDF.type, Nanopub.BPMN.ManualTask) in self._rdf:
-            return True
-        else:
-            return False
+        """Returns True if this FairStep is a bpmn:ManualTask, else False."""
+        return (self.this_step, RDF.type, Nanopub.BPMN.ManualTask) in self._rdf
 
+    @property
     def is_script_task(self):
-        """
-            Returns True if this FairStep is a bpmn:ScriptTask, else False.
-        """
-        if (self.this_step, RDF.type, Nanopub.BPMN.ScriptTask) in self._rdf:
-            return True
-        else:
-            return False
-        
+        """Returns True if this FairStep is a bpmn:ScriptTask, else False."""
+        return (self.this_step, RDF.type, Nanopub.BPMN.ScriptTask) in self._rdf
 
+    @property
     def description(self):
-        """
-            Returns the dcterms:description of this step (or a list, if more than one matching triple is found)
+        """Description.
+
+        Returns the dcterms:description of this step (or a list, if more than
+        one matching triple is found)
         """
 
-        descriptions = list(self._rdf.objects(subject=self.this_step, predicate=DCTERMS.description))
+        descriptions = list(self._rdf.objects(subject=self.this_step,
+                                              predicate=DCTERMS.description))
         if len(descriptions) == 0:
             return None
         elif len(descriptions) == 1:
@@ -165,7 +158,6 @@ class FairStep:
         else:
             return descriptions
 
-            
     def validate(self, verbose=True):
         """
             Checks whether this step rdf has sufficient information required of
@@ -178,15 +170,15 @@ class FairStep:
         conforms = True
         log = ''
 
-        if not self.is_pplan_step():
+        if not self.is_pplan_step:
             log += 'Step RDF does not say it is a pplan:Step\n'
             conforms = False
 
-        if not self.description():
+        if not self.description:
             log += 'Step RDF has no dcterms:description\n'
             conforms = False
 
-        if self.is_manual_task() == self.is_script_task():
+        if self.is_manual_task == self.is_script_task:
             log += 'Step RDF must be either a bpmn:ManualTask or a bpmn:ScriptTask\n'
             conforms = False
 
@@ -194,7 +186,6 @@ class FairStep:
             print(log)
 
         return conforms
-
 
     def __str__(self):
         """

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from .nanopub import Nanopub
 import rdflib
 from rdflib import RDF, DCTERMS
@@ -96,20 +98,13 @@ class FairStep:
         self.this_step = rdflib.URIRef(self._uri)
 
         # Set description of step to the raw function code
-        self.add_description(code)
+        self.description  = code
 
         # Specify that step is a pplan:Step
         self._rdf.add( (self.this_step, RDF.type, Nanopub.PPLAN.Step) )
 
         # Specify that step is a ScriptTask
         self._rdf.add( (self.this_step, RDF.type, Nanopub.BPMN.ScriptTask) )
-
-
-    def add_description(self, text):
-        """
-            Adds the given text string as a dcterms:description for this FairStep object.
-        """
-        self._rdf.add( (self.this_step, DCTERMS.description, rdflib.term.Literal(text)) )
 
 
     @property
@@ -148,7 +143,6 @@ class FairStep:
         Returns the dcterms:description of this step (or a list, if more than
         one matching triple is found)
         """
-
         descriptions = list(self._rdf.objects(subject=self.this_step,
                                               predicate=DCTERMS.description))
         if len(descriptions) == 0:
@@ -157,6 +151,19 @@ class FairStep:
             return descriptions[0]
         else:
             return descriptions
+
+    @description.setter
+    def description(self, value):
+        """
+        Adds the given text string as a dcterms:description for this FairStep
+        object.
+        """
+        if self.description is not None:
+            warn('A description was already defined, overwriting description')
+            self._rdf.remove((self.this_step, DCTERMS.description, None))
+        self._rdf.add((self.this_step,
+                       DCTERMS.description,
+                       rdflib.term.Literal(value)))
 
     def validate(self, verbose=True):
         """

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -82,14 +82,12 @@ class FairWorkflow:
         for step_uri in nx.topological_sort(G):
             yield self.get_step(str(step_uri))
 
+    @property
     def is_pplan_plan(self):
         """
         Returns True if this object's rdf specifies that it is a pplan:Plan
         """
-        if (self.this_plan, RDF.type, Nanopub.PPLAN.Plan) in self._rdf:
-            return True
-        else:
-            return False
+        return (self.this_plan, RDF.type, Nanopub.PPLAN.Plan) in self._rdf
 
     def get_step(self, uri):
         """
@@ -112,19 +110,16 @@ class FairWorkflow:
         else:
             return descriptions
 
-    def validate(self, verbose=True):
-        """
-            Checks whether this workflow's rdf has sufficient information required of
-            a workflow in the Plex ontology. If not, a message is printed explaining
-            the problem, and the function returns False.
+    def validate(self):
+        """Validate workflow.
 
-            If verbose is set to False, no explanation messages will be printed.
+        Checks whether this workflow's rdf has sufficient information required
+        of a workflow in the Plex ontology.
         """
-
         conforms = True
         log = ''
 
-        if not self.is_pplan_plan():
+        if not self.is_pplan_plan:
             log += 'Plan RDF does not say it is a pplan:Plan\n'
             conforms = False
 
@@ -136,11 +131,7 @@ class FairWorkflow:
             log += 'Plan RDF does not specify a first step (pwo:hasFirstStep)\n'
             conforms = False
 
-        if verbose:
-            print(log)
-
-        return conforms
-
+        assert conforms, log
 
     @property
     def rdf(self):

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -25,10 +25,10 @@ class FairWorkflow(RdfWrapper):
 
     def __init__(self, description, uri=DEFAULT_PLAN_URI):
         self._uri = uri
-        self.this = rdflib.URIRef(self._uri)
+        self.self_ref = rdflib.URIRef(self._uri)
 
         self._rdf = rdflib.Graph()
-        self._rdf.add((self.this, RDF.type, Nanopub.PPLAN.Plan))
+        self._rdf.add((self.self_ref, RDF.type, Nanopub.PPLAN.Plan))
         self.description = description
         self._steps = {}
         self._last_step_added = None
@@ -88,7 +88,7 @@ class FairWorkflow(RdfWrapper):
         """
         Returns True if this object's rdf specifies that it is a pplan:Plan
         """
-        return (self.this, RDF.type, Nanopub.PPLAN.Plan) in self._rdf
+        return (self.self_ref, RDF.type, Nanopub.PPLAN.Plan) in self._rdf
 
     def get_step(self, uri):
         """

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -131,13 +131,6 @@ class FairWorkflow(RdfWrapper):
 
         assert conforms, log
 
-    @property
-    def rdf(self):
-        """
-            Getter for the rdf graph describing this FairWorkflow.
-        """
-        return self._rdf
-
     def draw(self, show=True):
         """
             Ugly networkx implementation of graph visualization for this plex workflow.

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -27,8 +27,7 @@ class FairWorkflow:
 
         self._rdf = rdflib.Graph()
         self._rdf.add( (self.this_plan, RDF.type, Nanopub.PPLAN.Plan) )
-        self._rdf.add( (self.this_plan, DCTERMS.description, rdflib.term.Literal(description)) )
-
+        self.description = description
         self._steps = {}
         self._last_step_added = None
 
@@ -114,13 +113,23 @@ class FairWorkflow:
         the rdf for this workflow (or a list if more than one matching triple
         found)
         """
-        descriptions = list(self._rdf.objects(subject=self.this_plan, predicate=DCTERMS.description))
+        descriptions = list(self._rdf.objects(subject=self.this_plan,
+                                              predicate=DCTERMS.description))
         if len(descriptions) == 0:
             return None
         elif len(descriptions) == 1:
             return descriptions[0]
         else:
             return descriptions
+
+    @description.setter
+    def description(self, value):
+        if self.description is not None:
+            warn('A description was already defined, overwriting description')
+            self._rdf.remove((self.this_plan, DCTERMS.description, None))
+        self._rdf.add((self.this_plan,
+                       DCTERMS.description,
+                       rdflib.term.Literal(value)) )
 
     def validate(self):
         """Validate workflow.

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -1,5 +1,3 @@
-from warnings import warn
-
 import matplotlib.pyplot as plt
 import networkx as nx
 import rdflib

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -24,10 +24,7 @@ class FairWorkflow(RdfWrapper):
     """
 
     def __init__(self, description, uri=DEFAULT_PLAN_URI):
-        self._uri = uri
-        self.self_ref = rdflib.URIRef(self._uri)
-
-        self._rdf = rdflib.Graph()
+        super().__init__(uri=uri)
         self._rdf.add((self.self_ref, RDF.type, Nanopub.PPLAN.Plan))
         self.description = description
         self._steps = {}

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -31,18 +31,31 @@ class FairWorkflow:
 
         self._steps = {}
         self._last_step_added = None
-        self._first_step = None
 
     @property
     def first_step(self):
-        return self._first_step
+        """First step of workflow.
+
+        Returns:
+             First step of the workflow if existing. In weird cases (when the
+             RDF has multiple first steps and is thus invalid) return a list of
+             first steps.
+        """
+        first_steps = list(self._rdf.objects(
+            subject=self.this_plan, predicate=Nanopub.PWO.hasFirstStep))
+        if len(first_steps) == 0:
+            return None
+        elif len(first_steps) == 1:
+            return first_steps[0]
+        else:
+            return first_steps
 
     @first_step.setter
     def first_step(self, step: FairStep):
         """
         Sets the first step of this plex workflow to the given FairStep
         """
-        if self._first_step is not None:
+        if self.first_step is not None:
             warn('A first step was already defined, overwriting first step')
             self._rdf.remove((None, Nanopub.PWO.hasFirstStep, None))
         self._rdf.add((self.this_plan,
@@ -50,7 +63,6 @@ class FairWorkflow:
                        rdflib.URIRef(step.uri)))
         self._steps[step.uri] = step
         self._last_step_added = step
-        self._first_step = step
 
     def add(self, step:FairStep, follows:FairStep=None):
         """

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -7,7 +7,7 @@ class RdfWrapper:
     def __init__(self, uri):
         self._rdf = rdflib.Graph()
         self._uri = uri
-        self.this = rdflib.URIRef(self._uri)
+        self.self_ref = rdflib.URIRef(self._uri)
 
     @property
     def rdf(self) -> rdflib.Graph:
@@ -30,7 +30,7 @@ class RdfWrapper:
             if no attributes are found, or a list of attributes if multiple
             matching objects are found.
         """
-        objects = list(self._rdf.objects(subject=self.this,
+        objects = list(self._rdf.objects(subject=self.self_ref,
                                          predicate=predicate))
         if len(objects) == 0:
             return None
@@ -49,6 +49,6 @@ class RdfWrapper:
         """
         if self.get_attribute(predicate) is not None:
             warnings.warn(f'A predicate {predicate} was already defined'
-                          f'overwriting {predicate} for {self.this}')
-            self._rdf.remove((self.this, predicate, None))
-        self._rdf.add((self.this, predicate, value))
+                          f'overwriting {predicate} for {self.self_ref}')
+            self._rdf.remove((self.self_ref, predicate, None))
+        self._rdf.add((self.self_ref, predicate, value))

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -1,0 +1,44 @@
+import warnings
+
+import rdflib
+
+
+class RdfWrapper:
+    def __init__(self, uri):
+        self._rdf = rdflib.Graph()
+        self._uri = uri
+        self.this = rdflib.URIRef(self._uri)
+
+    def get_attribute(self, predicate):
+        """Get attribute.
+
+        Get attribute of this RDF.
+
+        Returns:
+            The object for which the predicate corresponds to predicate
+            argument and subject corresponds to this RDF itself. Return None
+            if no attributes are found, or a list of attributes if multiple
+            matching objects are found.
+        """
+        objects = list(self._rdf.objects(subject=self.this,
+                                         predicate=predicate))
+        if len(objects) == 0:
+            return None
+        elif len(objects) == 1:
+            return objects[0]
+        else:
+            return objects
+
+    def set_attribute(self, predicate, value):
+        """Set attribute.
+
+        Set attribute of this RDF. I.e. for the given `predicate` argument, set
+        the object to the given `value` argument for the subject
+        corresponding to this RDF. If the attribute already exists overwrite
+        it (but throw a warning).
+        """
+        if self.get_attribute(predicate) is not None:
+            warnings.warn(f'A predicate {predicate} was already defined'
+                          f'overwriting {predicate} for {self.this}')
+            self._rdf.remove((self.this, predicate, None))
+        self._rdf.add((self.this, predicate, value))

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -9,6 +9,16 @@ class RdfWrapper:
         self._uri = uri
         self.this = rdflib.URIRef(self._uri)
 
+    @property
+    def rdf(self) -> rdflib.Graph:
+        """Get the rdf graph."""
+        return self._rdf
+
+    @property
+    def uri(self) -> str:
+        """Get the URI for this RDF."""
+        return self._uri
+
     def get_attribute(self, predicate):
         """Get attribute.
 

--- a/test_plex_builder.ipynb
+++ b/test_plex_builder.ipynb
@@ -45,7 +45,7 @@
       "Step URI = http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step\n",
       "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "\n",
-      "_:N3de55aa4c69547488288abad399fe632 {\n",
+      "_:N29ee96ec16474dcf87c4b340c90cdead {\n",
       "    <http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step> a <http://dkm.fbk.eu/index.php/BPMN2_Ontology#ManualTask>,\n",
       "            <http://purl.org/net/p-plan#Step> ;\n",
       "        ns1:description \"Preheat an oven to 350 degrees F (175 degrees C).\" .\n",
@@ -701,25 +701,7 @@
      }
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "step.validate()"
    ]
@@ -1059,7 +1041,7 @@
     }
    ],
    "source": [
-    "step.is_pplan_step()"
+    "step.is_pplan_step"
    ]
   },
   {
@@ -1356,7 +1338,7 @@
     }
    ],
    "source": [
-    "step.description()"
+    "step.description"
    ]
   },
   {
@@ -1614,7 +1596,7 @@
     }
    ],
    "source": [
-    "step.is_manual_task()"
+    "step.is_manual_task"
    ]
   },
   {
@@ -1881,7 +1863,7 @@
     }
    ],
    "source": [
-    "step.is_script_task()"
+    "step.is_script_task"
    ]
   },
   {
@@ -1931,22 +1913,16 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Plan RDF does not specify a first step (pwo:hasFirstStep)\n",
-      "\n"
+     "ename": "AssertionError",
+     "evalue": "Plan RDF does not specify a first step (pwo:hasFirstStep)\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-12-601fde0b10f3>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Does it validate? No.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mworkflow\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalidate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/projects/fair-workflows/FAIRWorkbench/fairworkflows/fairworkflow.py\u001b[0m in \u001b[0;36mvalidate\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    131\u001b[0m             \u001b[0mconforms\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    132\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 133\u001b[0;31m         \u001b[0;32massert\u001b[0m \u001b[0mconforms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlog\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    134\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    135\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mstaticmethod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: Plan RDF does not specify a first step (pwo:hasFirstStep)\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1956,17 +1932,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Specify the first step in the plan\n",
-    "workflow.set_first_step(preheat_oven)"
+    "workflow.first_step = preheat_oven"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1978,7 +1954,7 @@
       "@prefix ns2: <http://purl.org/dc/terms/> .\n",
       "@prefix ns3: <http://purl.org/spar/pwo#> .\n",
       "\n",
-      "_:N39fd81010a5b4223b132131f37424fc3 {\n",
+      "_:N9a31e8073190451faf04c99411a70d0a {\n",
       "    <http://purl.org/nanopub/temp/mynanopub#plan> a <http://purl.org/net/p-plan#Plan> ;\n",
       "        ns2:description \"This is a test workflow.\" ;\n",
       "        ns3:hasFirstStep <http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step> .\n",
@@ -1999,7 +1975,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -2117,10 +2093,10 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.files.Source at 0x10c1d0cc0>"
+       "<graphviz.files.Source at 0x11c4d5e10>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2140,7 +2116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2152,7 +2128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2171,7 +2147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 20,
    "metadata": {
     "ExecutionTime": {
      "end_time": "2020-08-26T17:00:44.103279Z",
@@ -2315,7 +2291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2325,7 +2301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2335,7 +2311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -2344,22 +2320,27 @@
      "text": [
       "Workflow URI = http://purl.org/nanopub/temp/mynanopub#plan\n",
       "@prefix ns1: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .\n",
-      "@prefix ns2: <http://purl.org/spar/pwo#> .\n",
-      "@prefix ns3: <http://purl.org/dc/terms/> .\n",
+      "@prefix ns2: <http://purl.org/dc/terms/> .\n",
+      "@prefix ns3: <http://purl.org/spar/pwo#> .\n",
+      "@prefix ns4: <http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4#> .\n",
+      "@prefix ns5: <http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M#> .\n",
+      "@prefix ns6: <http://purl.org/nanopub/temp/mynanopub#> .\n",
+      "@prefix ns7: <http://purl.org/net/p-plan#> .\n",
+      "@prefix ns8: <http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#> .\n",
       "\n",
-      "_:Nba120c9e6c8c48d68e087a4645ae2e59 {\n",
-      "    <http://purl.org/nanopub/temp/mynanopub#plan> a <http://purl.org/net/p-plan#Plan> ;\n",
-      "        ns3:description \"This is a test workflow.\" ;\n",
-      "        ns2:hasFirstStep <http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step> .\n",
+      "_:N9a31e8073190451faf04c99411a70d0a {\n",
+      "    ns6:plan a ns7:Plan ;\n",
+      "        ns2:description \"This is a test workflow.\" ;\n",
+      "        ns3:hasFirstStep ns8:step .\n",
       "\n",
-      "    <http://purl.org/nanopub/temp/mynanopub#functiona_computational_step1598860870.624518> ns1:precedes <http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1598860870.638861> .\n",
+      "    ns6:functiona_computational_step1599571793.180508 ns1:precedes ns6:functionanother_computational_step1599571795.019922 .\n",
       "\n",
-      "    <http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1598860870.638861> ns1:precedes <http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1598860870.648441> .\n",
+      "    ns6:functionanother_computational_step1599571795.019922 ns1:precedes ns6:functionanother_computational_step1599571795.48994 .\n",
       "\n",
-      "    <http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step> ns1:precedes <http://purl.org/nanopub/temp/mynanopub#functiona_computational_step1598860870.624518>,\n",
-      "            <http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4#step> .\n",
+      "    ns8:step ns1:precedes ns6:functiona_computational_step1599571793.180508,\n",
+      "            ns4:step .\n",
       "\n",
-      "    <http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4#step> ns1:precedes <http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M#step> .\n",
+      "    ns4:step ns1:precedes ns5:step .\n",
       "}\n",
       "\n",
       "\n"
@@ -2381,7 +2362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -2391,7 +2372,7 @@
       "Step URI = http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step\n",
       "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "\n",
-      "_:Nd05bd1d9c26e4d85a927bf875a7ea7d1 {\n",
+      "_:N9ea7d36478ae482cbe0d4db1d6303fc7 {\n",
       "    <http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step> a <http://dkm.fbk.eu/index.php/BPMN2_Ontology#ManualTask>,\n",
       "            <http://purl.org/net/p-plan#Step> ;\n",
       "        ns1:description \"Preheat an oven to 350 degrees F (175 degrees C).\" .\n",
@@ -2401,39 +2382,43 @@
       "Step URI = http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4#step\n",
       "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "\n",
-      "_:N1be715df3c6c4329880b64bf2cbb9f04 {\n",
+      "_:Nd0059605b9dd4beb93a6de83118b4b49 {\n",
       "    <http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4#step> a <http://dkm.fbk.eu/index.php/BPMN2_Ontology#ManualTask>,\n",
       "            <http://purl.org/net/p-plan#Step> ;\n",
       "        ns1:description \"Melt the butter in a skillet over medium heat. Add the apple and onion to the melted butter, season with the curry powder, and cook and stir until the apple and onion are tender, 7 to 10 minutes. Stir the mushroom soup and half-and-half into the mixture until completely combined; spoon over the chicken pieces.\" .\n",
       "}\n",
       "\n",
       "\n",
-      "Step URI = http://purl.org/nanopub/temp/mynanopub#functiona_computational_step1598860870.624518\n",
-      "@prefix ns1: <http://purl.org/dc/terms/> .\n",
-      "\n",
-      "_:N3a9b4644fb98488bb92d9714e4632ecf {\n",
-      "    <http://purl.org/nanopub/temp/mynanopub#functiona_computational_step1598860870.624518> ns1:description \"\"\"def a_computational_step(x, y):\n",
-      "    \\\"\\\"\\\"A test function that adds two numbers\\\"\\\"\\\"\n",
-      "    return x + y\n",
-      "\"\"\" .\n",
-      "}\n",
-      "\n",
-      "\n",
       "Step URI = http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M#step\n",
       "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "\n",
-      "_:N3c3b721b334441a49db4cd77e5be0d41 {\n",
+      "_:N75af2d8a32194c3d861fb4440f6e2540 {\n",
       "    <http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M#step> a <http://dkm.fbk.eu/index.php/BPMN2_Ontology#ManualTask>,\n",
       "            <http://purl.org/net/p-plan#Step> ;\n",
       "        ns1:description \"Arrange the chicken pieces in a single layer in a 9x13-inch baking dish. Season the chicken liberally with salt, pepper, and the paprika; set aside.\" .\n",
       "}\n",
       "\n",
       "\n",
-      "Step URI = http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1598860870.638861\n",
+      "Step URI = http://purl.org/nanopub/temp/mynanopub#functiona_computational_step1599571793.180508\n",
       "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "\n",
-      "_:N725aa86c208144e4926b9857fd9ba18f {\n",
-      "    <http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1598860870.638861> ns1:description \"\"\"@fairstep(workflow)\n",
+      "_:N401148b59e1047368797d311438cdc85 {\n",
+      "    <http://purl.org/nanopub/temp/mynanopub#functiona_computational_step1599571793.180508> a <http://dkm.fbk.eu/index.php/BPMN2_Ontology#ScriptTask>,\n",
+      "            <http://purl.org/net/p-plan#Step> ;\n",
+      "        ns1:description \"\"\"def a_computational_step(x, y):\n",
+      "    \\\"\\\"\\\"A test function that adds two numbers\\\"\\\"\\\"\n",
+      "    return x + y\n",
+      "\"\"\" .\n",
+      "}\n",
+      "\n",
+      "\n",
+      "Step URI = http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1599571795.019922\n",
+      "@prefix ns1: <http://purl.org/dc/terms/> .\n",
+      "\n",
+      "_:Nf873e46a74e24a8e97c1874ef9ebaa3a {\n",
+      "    <http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1599571795.019922> a <http://dkm.fbk.eu/index.php/BPMN2_Ontology#ScriptTask>,\n",
+      "            <http://purl.org/net/p-plan#Step> ;\n",
+      "        ns1:description \"\"\"@fairstep(workflow)\n",
       "def another_computational_step(a, b):\n",
       "    \\\"\\\"\\\"Another script task\\\"\\\"\\\"\n",
       "    return a * b\n",
@@ -2441,11 +2426,13 @@
       "}\n",
       "\n",
       "\n",
-      "Step URI = http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1598860870.648441\n",
+      "Step URI = http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1599571795.48994\n",
       "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "\n",
-      "_:N2428ca47a30044778c789adce7b41d4a {\n",
-      "    <http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1598860870.648441> ns1:description \"\"\"@fairstep(workflow)\n",
+      "_:N19d35b64f03848dc810bd04d812115ce {\n",
+      "    <http://purl.org/nanopub/temp/mynanopub#functionanother_computational_step1599571795.48994> a <http://dkm.fbk.eu/index.php/BPMN2_Ontology#ScriptTask>,\n",
+      "            <http://purl.org/net/p-plan#Step> ;\n",
+      "        ns1:description \"\"\"@fairstep(workflow)\n",
       "def another_computational_step(a, b):\n",
       "    \\\"\\\"\\\"Another script task\\\"\\\"\\\"\n",
       "    return a * b\n",

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -89,16 +89,3 @@ def test_fairstep_from_function():
 def test_validation():
     step = FairStep(uri='http://www.example.org/step')
     assert step.validate() is False
-
-
-def test_overwrite_description():
-    step = FairStep()
-    assert step.description is None
-    step.description = 'Description 1'
-    assert str(step.description) == 'Description 1'
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        step.description = 'Description 2'
-        assert len(w) == 1
-        assert issubclass(w[-1].category, UserWarning)
-    assert str(step.description) == 'Description 2'

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -31,10 +31,10 @@ def test_fairstep_from_nanopub():
         step = FairStep(uri=uri, from_nanopub=True)
         assert step is not None
         assert step.validate()
-        assert step.is_pplan_step()
-        assert step.description() is not None
-        assert step.is_manual_task() is True
-        assert step.is_script_task() is False
+        assert step.is_pplan_step
+        assert step.description is not None
+        assert step.is_manual_task
+        assert not step.is_script_task
 
 
 @pytest.mark.flaky(max_runs=10)
@@ -57,10 +57,10 @@ def test_fairstep_from_nanopub_without_fragment():
         step = FairStep(uri=uri, from_nanopub=True)
         assert step is not None
         assert step.validate()
-        assert step.is_pplan_step()
-        assert step.description() is not None
-        assert step.is_manual_task() is True
-        assert step.is_script_task() is False
+        assert step.is_pplan_step
+        assert step.description is not None
+        assert step.is_manual_task
+        assert not step.is_script_task
 
 
 def test_fairstep_from_function():
@@ -74,10 +74,10 @@ def test_fairstep_from_function():
 
     assert step is not None
     assert step.validate()
-    assert step.is_pplan_step()
-    assert step.description() is not None
-    assert step.is_manual_task() is False
-    assert step.is_script_task() is True
+    assert step.is_pplan_step
+    assert step.description is not None
+    assert not step.is_manual_task
+    assert step.is_script_task
 
     assert step.__str__() is not None
     assert len(step.__str__()) > 0

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -30,7 +30,7 @@ def test_fairstep_from_nanopub():
     for uri in nanopub_uris:
         step = FairStep(uri=uri, from_nanopub=True)
         assert step is not None
-        assert step.validate()
+        step.validate()
         assert step.is_pplan_step
         assert step.description is not None
         assert step.is_manual_task
@@ -56,7 +56,7 @@ def test_fairstep_from_nanopub_without_fragment():
     for uri in nanopub_uris:
         step = FairStep(uri=uri, from_nanopub=True)
         assert step is not None
-        assert step.validate()
+        step.validate()
         assert step.is_pplan_step
         assert step.description is not None
         assert step.is_manual_task
@@ -73,7 +73,7 @@ def test_fairstep_from_function():
     step = FairStep(func=add)
 
     assert step is not None
-    assert step.validate()
+    step.validate()
     assert step.is_pplan_step
     assert step.description is not None
     assert not step.is_manual_task
@@ -86,4 +86,5 @@ def test_fairstep_from_function():
 
 def test_validation():
     step = FairStep(uri='http://www.example.org/step')
-    assert step.validate() is False
+    with pytest.raises(AssertionError):
+        step.validate()

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pytest
 import requests
 

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import requests
 
@@ -89,3 +91,14 @@ def test_validation():
     assert step.validate() is False
 
 
+def test_overwrite_description():
+    step = FairStep()
+    assert step.description is None
+    step.description = 'Description 1'
+    assert str(step.description) == 'Description 1'
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        step.description = 'Description 2'
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+    assert str(step.description) == 'Description 2'

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -42,11 +42,7 @@ class TestFairWorkflow:
 
     def test_overwrite_first_step(self):
         # First step should be step 1
-        first_step = list(self.workflow._rdf.objects(
-            subject=self.workflow.this_plan,
-            predicate=Nanopub.PWO.hasFirstStep))
-        assert len(first_step) == 1
-        assert str(first_step[0]) == self.step1.uri
+        assert str(self.workflow.first_step) == self.step1.uri
 
         # Reset first step to step 2
         with warnings.catch_warnings(record=True) as w:
@@ -55,12 +51,7 @@ class TestFairWorkflow:
             assert len(w) == 1
             assert issubclass(w[-1].category, UserWarning)
 
-        # Check if first step in rdf is replaced
-        first_step = list(self.workflow._rdf.objects(
-            subject=self.workflow.this_plan,
-            predicate=Nanopub.PWO.hasFirstStep))
-        assert len(first_step) == 1
-        assert str(first_step[0]) == self.step2.uri
+        assert str(self.workflow.first_step) == self.step2.uri
 
     def test_iterator(self):
         """Test iterating over the workflow."""

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -40,19 +40,6 @@ class TestFairWorkflow:
         assert len(workflow.__str__()) > 0
         assert workflow.rdf is not None
 
-    def test_overwrite_first_step(self):
-        # First step should be step 1
-        assert str(self.workflow.first_step) == self.step1.uri
-
-        # Reset first step to step 2
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            self.workflow.first_step = self.step2
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-
-        assert str(self.workflow.first_step) == self.step2.uri
-
     def test_iterator(self):
         """Test iterating over the workflow."""
         right_order_steps = [self.step1, self.step2, self.step3]

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -1,5 +1,7 @@
 import warnings
 
+import pytest
+
 from fairworkflows import FairWorkflow, FairStep, fairstep, Nanopub
 
 
@@ -21,16 +23,18 @@ class TestFairWorkflow:
         assert workflow is not None
         assert str(workflow.description) == self.test_description
 
-        assert not workflow.validate()
+        with pytest.raises(AssertionError):
+            workflow.validate()
 
         workflow.add(self.step2, follows=self.step1)
         workflow.add(self.step3, follows=self.step2)
 
-        assert not workflow.validate()
+        with pytest.raises(AssertionError):
+            workflow.validate()
 
         workflow.first_step = self.step1
 
-        assert workflow.validate()
+        workflow.validate()
 
         assert workflow.__str__() is not None
         assert len(workflow.__str__()) > 0
@@ -73,11 +77,12 @@ class TestFairWorkflow:
         def test_fn(x, y):
             return x * y
 
-        assert workflow.validate() is False
+        with pytest.raises(AssertionError):
+            workflow.validate()
 
         test_fn(1, 2)
 
-        assert workflow.validate() is True
+        workflow.validate()
 
     def test_draw(self):
         # Check for errors when calling draw()...

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -1,8 +1,6 @@
-import warnings
-
 import pytest
 
-from fairworkflows import FairWorkflow, FairStep, fairstep, Nanopub
+from fairworkflows import FairWorkflow, FairStep, fairstep
 
 
 class TestFairWorkflow:

--- a/tests/test_rdf_wrapper.py
+++ b/tests/test_rdf_wrapper.py
@@ -1,0 +1,24 @@
+import warnings
+
+import rdflib
+
+from fairworkflows.rdf_wrapper import RdfWrapper
+
+
+class TestRdfWrapper:
+
+    def test_set_and_get_attribute(self):
+        test_predicate = rdflib.RDF.type
+        test_value_1 = rdflib.term.Literal('test_value_1')
+        test_value_2 = rdflib.term.Literal('test_value_2')
+        wrapper = RdfWrapper(uri='test')
+        wrapper.set_attribute(test_predicate, test_value_1)
+        assert wrapper.get_attribute(test_predicate) == test_value_1
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wrapper.set_attribute(test_predicate, test_value_2)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+
+        assert wrapper.get_attribute(test_predicate) == test_value_2

--- a/tests/test_rdf_wrapper.py
+++ b/tests/test_rdf_wrapper.py
@@ -11,10 +11,13 @@ class TestRdfWrapper:
         test_predicate = rdflib.RDF.type
         test_value_1 = rdflib.term.Literal('test_value_1')
         test_value_2 = rdflib.term.Literal('test_value_2')
+
         wrapper = RdfWrapper(uri='test')
         wrapper.set_attribute(test_predicate, test_value_1)
         assert wrapper.get_attribute(test_predicate) == test_value_1
 
+        # Setting the attribute another time should overwrite, and throw a
+        # warning.
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             wrapper.set_attribute(test_predicate, test_value_2)


### PR DESCRIPTION
- For `FairWorkflow`, make `first_step` and `is_pplanplan` properties
- For `FairStep`, make `description`, `is_maunal_task`, `is_script_task` and `is_pplan_step` properties
- Let `FairWorkflow` and `FairStep` classes inherit from new `RdfWrapper` class
- For getting and setting properties that are actual attributes of the RDF (like first_step, and description) make use of the `get_attribute` and `set_attribute` methods of `RdfWrapper` to manipulate the RDF graph.
- Use assertion in `validate()`