### PR TITLE
Publish FairSteps and FairWorkflows as nanopublications

### DIFF
--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -98,7 +98,7 @@ class FairStep(RdfWrapper):
         # If this step has been modified from a previously publised step, include this in the derived_from PROV (if applicable)
         derived_from = None
         if self._is_published:
-            if self.is_modified is True:
+            if self.is_modified:
                 derived_from = self._uri
             else:
                 warnings.warn(f'Cannot publish() FairStep. This step is already published (at {self._uri}) and has not been modified.')

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -25,7 +25,6 @@ class FairStep(RdfWrapper):
         super().__init__(uri=uri)
 
         self._is_published = False
-        self._is_modified = False
 
         if func:
             self.from_function(func)
@@ -100,7 +99,7 @@ class FairStep(RdfWrapper):
         # If this step has been modified from a previously publised step, include this in the derived_from PROV (if applicable)
         derived_from = None
         if self._is_published is True:
-            if self._is_modified is True:
+            if self.is_modified is True:
                 derived_from = self._uri
             else:
                 print(f'Cannot publish() FairStep. This step is already published (at {self._uri}) and has not been modified.')

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -103,9 +103,12 @@ class FairStep(RdfWrapper):
                 warnings.warn(f'Cannot publish() FairStep. This step is already published (at {self._uri}) and has not been modified.')
                 return
 
-        # Publish the step rdf as a nanopub
-        self._uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
-#        out = Nanopub.rdf(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
+        # Publish the rdf of this step as a nanopub
+        np_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
+
+        # Set the new (published) URI of this fair step, which should be the nanopub URI plus a fragment given by the name of self.self_ref
+        self._uri = np_uri + '#' + str(self.self_ref)
+        
 
         self._is_published = True
         self._is_modified = False

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -102,7 +102,7 @@ class FairStep(RdfWrapper):
                 derived_from = self._uri
             else:
                 warnings.warn(f'Cannot publish() FairStep. This step is already published (at {self._uri}) and has not been modified.')
-                return False
+                return
 
         # Publish the rdf of this step as a nanopub
         np_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
@@ -113,7 +113,6 @@ class FairStep(RdfWrapper):
         self._is_published = True
         self._is_modified = False
 
-        return True
 
     def from_function(self, func):
         """

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -21,8 +21,6 @@ class FairStep(RdfWrapper):
                  from_nanopub=False, func=None):
         super().__init__(uri=uri, ref_name='step')
 
-        self._is_published = False
-
         if func:
             self.from_function(func)
         elif from_nanopub:
@@ -87,32 +85,6 @@ class FairStep(RdfWrapper):
         # Record that this RDF originates from a published source
         self._is_published = True
 
-
-    def publish_as_nanopub(self):
-        """
-        Publishes the rdf for this FairStep as a nanopublication.
-        Returns True if published successfully.
-        """
-
-        # If this step has been modified from a previously publised step, include this in the derived_from PROV (if applicable)
-        derived_from = None
-        if self._is_published:
-            if self.is_modified:
-                derived_from = self._uri
-            else:
-                warnings.warn(f'Cannot publish() FairStep. This step is already published (at {self._uri}) and has not been modified.')
-                return
-
-        # Publish the rdf of this step as a nanopub
-        publication_info  = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
-
-        # Set the new, published, URI of this fair step, which should be whatever the (published) URI of the concept that was introduced is.
-        # Note that this is NOT the nanopub's URI, since the nanopub is not the step/workflow. The rdf object describing the step/workflow
-        # is contained in the assertion graph of the nanopub, and has its own URI.
-        self._uri = publication_info['concept_uri']
-        
-        self._is_published = True
-        self._is_modified = False
 
     def from_function(self, func):
         """

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -97,7 +97,7 @@ class FairStep(RdfWrapper):
 
         # If this step has been modified from a previously publised step, include this in the derived_from PROV (if applicable)
         derived_from = None
-        if self._is_published is True:
+        if self._is_published:
             if self.is_modified is True:
                 derived_from = self._uri
             else:
@@ -196,5 +196,4 @@ class FairStep(RdfWrapper):
         s = f'Step URI = {self._uri}\n'
         s += self._rdf.serialize(format='trig').decode('utf-8')
         return s
-
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -51,7 +51,6 @@ class FairStep(RdfWrapper):
             are found, then ALL triples in the assertion are added to the rdf graph for this FairStep.
         """
 
-
         # Work out the nanopub URI by defragging the step URI
         nanopub_uri, frag = urldefrag(uri)
 
@@ -105,14 +104,15 @@ class FairStep(RdfWrapper):
                 return
 
         # Publish the rdf of this step as a nanopub
-        nanopub_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
+        publication_info  = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
 
-        # Set the new (published) URI of this fair step, which should be the nanopub URI plus a fragment given by the name of self.self_ref
-        self._uri = nanopub_uri + '#' + str(self.self_ref)
+        # Set the new, published, URI of this fair step, which should be whatever the (published) URI of the concept that was introduced is.
+        # Note that this is NOT the nanopub's URI, since the nanopub is not the step/workflow. The rdf object describing the step/workflow
+        # is contained in the assertion graph of the nanopub, and has its own URI.
+        self._uri = publication_info['concept_uri']
         
         self._is_published = True
         self._is_modified = False
-
 
     def from_function(self, func):
         """

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -68,7 +68,7 @@ class FairStep(RdfWrapper):
             if len(concepts_introduced) == 0:
                 raise ValueError('This nanopub does not introduce any concepts. Please provide URI to the step itself (not just the nanopub).')
             elif len(concepts_introduced) > 0:
-                step_uri = concepts_introduced[0]
+                step_uri = str(concepts_introduced[0])
 
             print('Assuming step URI is', step_uri)
 
@@ -92,6 +92,7 @@ class FairStep(RdfWrapper):
     def publish_as_nanopub(self):
         """
         Publishes the rdf for this FairStep as a nanopublication.
+        Returns True if published successfully.
         """
 
         # If this step has been modified from a previously publised step, include this in the derived_from PROV (if applicable)
@@ -101,7 +102,7 @@ class FairStep(RdfWrapper):
                 derived_from = self._uri
             else:
                 warnings.warn(f'Cannot publish() FairStep. This step is already published (at {self._uri}) and has not been modified.')
-                return
+                return False
 
         # Publish the rdf of this step as a nanopub
         np_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
@@ -109,9 +110,10 @@ class FairStep(RdfWrapper):
         # Set the new (published) URI of this fair step, which should be the nanopub URI plus a fragment given by the name of self.self_ref
         self._uri = np_uri + '#' + str(self.self_ref)
         
-
         self._is_published = True
         self._is_modified = False
+
+        return True
 
     def from_function(self, func):
         """

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -8,7 +8,6 @@ from .nanopub import Nanopub
 from .rdf_wrapper import RdfWrapper
 
 
-
 class FairStep(RdfWrapper):
     """
         Class for building, validating and publishing Fair Steps, as described by the plex ontology in the publication:
@@ -20,7 +19,7 @@ class FairStep(RdfWrapper):
 
     def __init__(self, step_rdf: rdflib.Graph = None, uri=None,
                  from_nanopub=False, func=None):
-        super().__init__(uri=uri)
+        super().__init__(uri=uri, ref_name='step')
 
         self._is_published = False
 
@@ -105,7 +104,11 @@ class FairStep(RdfWrapper):
                 return
 
         # Publish the step rdf as a nanopub
-        self._uri = Nanopub.publish(self._rdf, introduces_concept=self._uri, derived_from=derived_from)
+        self._uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
+#        out = Nanopub.rdf(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
+
+        self._is_published = True
+        self._is_modified = False
 
     def from_function(self, func):
         """
@@ -118,7 +121,7 @@ class FairStep(RdfWrapper):
         self._uri = 'http://purl.org/nanopub/temp/mynanopub#function' + name
 
         # Set description of step to the raw function code
-        self.description  = code
+        self.description = code
 
         # Specify that step is a pplan:Step
         self._rdf.add((self.self_ref, RDF.type, Nanopub.PPLAN.Step))

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -29,7 +29,7 @@ class FairStep(RdfWrapper):
             if step_rdf:
                 self._rdf = step_rdf
 
-                if self._uri not in step_rdf.subjects():
+                if rdflib.URIRef(self._uri) not in step_rdf.subjects():
                     warnings.warn(f"Warning: Provided URI '{self._uri}' does not match any subject in provided rdf graph.")
 
             else:

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -53,10 +53,10 @@ class FairStep(RdfWrapper):
 
 
         # Work out the nanopub URI by defragging the step URI
-        np_uri, frag = urldefrag(uri)
+        nanopub_uri, frag = urldefrag(uri)
 
         # Fetch the nanopub
-        np = Nanopub.fetch(np_uri)
+        np = Nanopub.fetch(nanopub_uri)
 
         # If there was no fragment in the original uri, then the uri was already the nanopub one.
         # Try to work out what the step's URI is, by looking at what the np is introducing.
@@ -79,7 +79,7 @@ class FairStep(RdfWrapper):
 
         # Check that the nanopub's assertion actually contains triples refering to the given step's uri
         if (rdflib.URIRef(self._uri), None, None) not in np.assertion:
-            raise ValueError(f'No triples pertaining to the specified step (uri={step_uri}) were found in the assertion graph of the corresponding nanopublication (uri={np_uri})')
+            raise ValueError(f'No triples pertaining to the specified step (uri={step_uri}) were found in the assertion graph of the corresponding nanopublication (uri={nanopub_uri})')
 
         # Else extract all triples in the assertion into the rdf graph for this step
         self._rdf = rdflib.Graph()
@@ -105,10 +105,10 @@ class FairStep(RdfWrapper):
                 return
 
         # Publish the rdf of this step as a nanopub
-        np_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
+        nanopub_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
 
         # Set the new (published) URI of this fair step, which should be the nanopub URI plus a fragment given by the name of self.self_ref
-        self._uri = np_uri + '#' + str(self.self_ref)
+        self._uri = nanopub_uri + '#' + str(self.self_ref)
         
         self._is_published = True
         self._is_modified = False

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -1,6 +1,6 @@
 import inspect
 from urllib.parse import urldefrag
-
+import warnings
 import rdflib
 from rdflib import RDF, DCTERMS
 
@@ -102,7 +102,7 @@ class FairStep(RdfWrapper):
             if self.is_modified is True:
                 derived_from = self._uri
             else:
-                print(f'Cannot publish() FairStep. This step is already published (at {self._uri}) and has not been modified.')
+                warnings.warn(f'Cannot publish() FairStep. This step is already published (at {self._uri}) and has not been modified.')
                 return
 
         # Publish the step rdf as a nanopub

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -194,10 +194,10 @@ class FairWorkflow(RdfWrapper):
                 return False
 
         # Publish the rdf of this plan as a nanopub
-        np_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
+        nanopub_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
 
         # Set the new (published) URI of this fair workflow, which should be the nanopub URI plus a fragment given by the name of self.self_ref
-        self._uri = np_uri + '#' + str(self.self_ref)
+        self._uri = nanopub_uri + '#' + str(self.self_ref)
 
         self._is_published = True
         self._is_modified = False

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -177,34 +177,6 @@ class FairWorkflow(RdfWrapper):
                 'Cannot produce visualization of RDF, you need to install '
                 'graphviz dependency https://graphviz.org/')
 
-
-    def publish_as_nanopub(self):
-        """
-        Publishes the rdf for this FairWorkflow as a nanopublication.
-        Returns True if published successfully.
-        """
-
-        # If this plan has been modified from a previously published plan, include this in the derived_from PROV (if applicable)
-        derived_from = None
-        if self._is_published:
-            if self.is_modified:
-                derived_from = self._uri
-            else:
-                warnings.warn(f'Cannot publish() FairWorkflow. This plan is already published (at {self._uri}) and has not been modified.')
-                return False
-
-        # Publish the rdf of this plan as a nanopub
-        nanopub_uri = Nanopub.publish(self._rdf, introduces_concept=self.self_ref, derived_from=derived_from)
-
-        # Set the new (published) URI of this fair workflow, which should be the nanopub URI plus a fragment given by the name of self.self_ref
-        self._uri = nanopub_uri + '#' + str(self.self_ref)
-
-        self._is_published = True
-        self._is_modified = False
-
-        return True
-
-
     def __str__(self):
         """
             Returns string representation of this FairWorkflow object.

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
 

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -186,8 +186,8 @@ class FairWorkflow(RdfWrapper):
 
         # If this plan has been modified from a previously published plan, include this in the derived_from PROV (if applicable)
         derived_from = None
-        if self._is_published is True:
-            if self.is_modified is True:
+        if self._is_published:
+            if self.is_modified:
                 derived_from = self._uri
             else:
                 warnings.warn(f'Cannot publish() FairWorkflow. This plan is already published (at {self._uri}) and has not been modified.')

--- a/fairworkflows/nanopub.py
+++ b/fairworkflows/nanopub.py
@@ -220,8 +220,20 @@ class Nanopub:
     def to_rdf(assertionrdf, uri=DEFAULT_URI, introduces_concept=None, derived_from=None, attributed_to=None, nanopub_author=None):
         """
         Return the nanopub rdf, with given assertion and (defrag'd) URI, but does not sign or publish.
-        Any blank nodes in the rdf graph are replaced with the nanopub's uri, with the blank node name
-        as a fragment.
+        Any blank nodes in the rdf graph are replaced with the nanopub's URI, with the blank node name
+        as a fragment. For example, if the blank node is called 'step', that would result in a URI composed of the
+        nanopub's (base) URI, followed by #step.
+
+        If introduces_concept is given (string, or rdflib.URIRef), the pubinfo graph will note that this nanopub npx:introduces the given URI.
+        If a blank node (rdflib.term.BNode) is given instead of a URI, the blank node will be converted to a URI
+        derived from the nanopub's URI with a fragment (#) made from the blank node's name.
+
+        If derived_from is given (string or rdflib.URIRef), the provenance graph will note that this nanopub prov:wasDerivedFrom the given URI.
+
+        If attributed_to is given (string or rdflib.URIRef), the provenance graph will note that this nanopub prov:wasAttributedTo the given URI.
+
+        if nanopub_author is given (string or rdflib.URIRef), the pubinfo graph will note that this nanopub prov:wasAttributedTo the given URI.
+
         """
 
         # Make sure passed URI is defrag'd        
@@ -283,6 +295,7 @@ class Nanopub:
         pubInfo.add((this_np[''], Nanopub.PROV.generatedAtTime, creationtime))
 
         if attributed_to:
+            attributed_to = rdflib.URIRef(attributed_to)
             provenance.add((this_np.assertion, Nanopub.PROV.wasAttributedTo, attributed_to))
 
         if derived_from:
@@ -292,6 +305,7 @@ class Nanopub:
             provenance.add((this_np.assertion, Nanopub.PROV.wasDerivedFrom, derived_from))
 
         if nanopub_author:
+            nanopub_author = rdflib.URIRef(nanopub_author)
             pubInfo.add((this_np[''], Nanopub.PROV.wasAttributedTo, nanopub_author))
 
         if introduces_concept:

--- a/fairworkflows/nanopub.py
+++ b/fairworkflows/nanopub.py
@@ -217,7 +217,7 @@ class Nanopub:
 
 
     @staticmethod
-    def rdf(assertionrdf, uri=DEFAULT_URI, introduces_concept=None, derived_from=None, attributed_to=None, nanopub_author=None):
+    def to_rdf(assertionrdf, uri=DEFAULT_URI, introduces_concept=None, derived_from=None, attributed_to=None, nanopub_author=None):
         """
         Return the nanopub rdf, with given assertion and (defrag'd) URI, but does not sign or publish.
         Any blank nodes in the rdf graph are replaced with the nanopub's uri, with the blank node name
@@ -314,9 +314,9 @@ class Nanopub:
         """
 
         if uri is None:
-            np_rdf = Nanopub.rdf(assertionrdf, introduces_concept=introduces_concept, derived_from=derived_from)
+            np_rdf = Nanopub.to_rdf(assertionrdf, introduces_concept=introduces_concept, derived_from=derived_from)
         else:
-            np_rdf = Nanopub.rdf(assertionrdf, uri=uri, introduces_concept=introduces_concept, derived_from=derived_from)
+            np_rdf = Nanopub.to_rdf(assertionrdf, uri=uri, introduces_concept=introduces_concept, derived_from=derived_from)
 
         # Create a temporary dir for files created during serializing and signing
         tempdir = tempfile.mkdtemp()

--- a/fairworkflows/nanopub.py
+++ b/fairworkflows/nanopub.py
@@ -267,6 +267,9 @@ class Nanopub:
         pubInfo.add((this_np[''], Nanopub.PROV.generatedAtTime, creationtime))
 
         if introduces_concept:
+            # Convert introduces_concept URI to an rdflib term first (if necessary)
+            introduces_concept = rdflib.URIRef(introduces_concept)
+
             pubInfo.add((this_np[''], Nanopub.NPX.introduces, introduces_concept))
 
         return np_rdf

--- a/fairworkflows/nanopub.py
+++ b/fairworkflows/nanopub.py
@@ -315,11 +315,24 @@ class Nanopub:
 
         # Sign the nanopub and publish it
         signed_file = nanopub_wrapper.sign(unsigned_fname)
-        nanopuburi = nanopub_wrapper.publish(signed_file)
+        nanopub_uri = nanopub_wrapper.publish(signed_file)
+        publication_info = {'nanopub_uri': nanopub_uri}
+        print(f'Published to {nanopub_uri}')
 
-        print(f'Published to {nanopuburi}')
-        return nanopuburi
+        if introduces_concept:
+            # Construct the (actually published) URI of the concept being introduced by this nanopub.
+            # This is only necessary if a blank node was passed as introduces_concept. In that case
+            # this module's to_rdf() function replaces the blank node with the base nanopub's URI
+            # and appends a fragment, given by the 'name' of the blank node. For example, if a blank node
+            # with name 'step' was passed as introduces_concept, the concept will be published with a URI
+            # that looks like [published nanopub URI]#step.
+            
+            concept_uri = nanopub_uri + '#' + str(introduces_concept)
+            publication_info['concept_uri'] = concept_uri
+            print(f'Published concept to {concept_uri}')
 
+        return publication_info
+    
 
     @staticmethod
     def claim(text, rdftriple=None):

--- a/fairworkflows/nanopub.py
+++ b/fairworkflows/nanopub.py
@@ -321,16 +321,19 @@ class Nanopub:
 
 
     @staticmethod
-    def publish(assertionrdf, uri=None, introduces_concept=None, derived_from=None):
+    def publish(assertionrdf, uri=None, introduces_concept=None, derived_from=None, attributed_to=None, nanopub_author=None):
         """
         Publish the given assertion as a nanopublication with the given URI.
         Uses np commandline tool to sign and publish.
+
+        The meanings and usage of uri, introduces_concept, derived_from, attributed_to, and nanopub_author are the same as described for the to_rdf()
+        method in this module.
         """
 
         if uri is None:
-            np_rdf = Nanopub.to_rdf(assertionrdf, introduces_concept=introduces_concept, derived_from=derived_from)
+            np_rdf = Nanopub.to_rdf(assertionrdf, introduces_concept=introduces_concept, derived_from=derived_from, attributed_to=attributed_to, nanopub_author=nanopub_author)
         else:
-            np_rdf = Nanopub.to_rdf(assertionrdf, uri=uri, introduces_concept=introduces_concept, derived_from=derived_from)
+            np_rdf = Nanopub.to_rdf(assertionrdf, uri=uri, introduces_concept=introduces_concept, derived_from=derived_from, attributed_to=attributed_to, nanopub_author=nanopub_author)
 
         # Create a temporary dir for files created during serializing and signing
         tempdir = tempfile.mkdtemp()

--- a/fairworkflows/nanopub.py
+++ b/fairworkflows/nanopub.py
@@ -217,7 +217,7 @@ class Nanopub:
 
 
     @staticmethod
-    def rdf(assertionrdf, uri=DEFAULT_URI, introduces_concept=None, derived_from=None):
+    def rdf(assertionrdf, uri=DEFAULT_URI, introduces_concept=None, derived_from=None, attributed_to=None, nanopub_author=None):
         """
         Return the nanopub rdf, with given assertion and (defrag'd) URI, but does not sign or publish.
         Any blank nodes in the rdf graph are replaced with the nanopub's uri, with the blank node name
@@ -266,7 +266,11 @@ class Nanopub:
 
         creationtime = rdflib.Literal(datetime.now(),datatype=XSD.dateTime)
         provenance.add((this_np.assertion, Nanopub.PROV.generatedAtTime, creationtime))
-        provenance.add((this_np.assertion, Nanopub.PROV.wasAttributedTo, this_np.experimentScientist))
+
+        pubInfo.add((this_np[''], Nanopub.PROV.generatedAtTime, creationtime))
+
+        if attributed_to:
+            provenance.add((this_np.assertion, Nanopub.PROV.wasAttributedTo, attributed_to))
 
         if derived_from:
             # Convert derived_from URI to an rdflib term first (if necessary)
@@ -274,8 +278,8 @@ class Nanopub:
 
             provenance.add((this_np.assertion, Nanopub.PROV.wasDerivedFrom, derived_from))
 
-        pubInfo.add((this_np[''], Nanopub.PROV.wasAttributedTo, Nanopub.AUTHOR.DrBob))
-        pubInfo.add((this_np[''], Nanopub.PROV.generatedAtTime, creationtime))
+        if nanopub_author:
+            pubInfo.add((this_np[''], Nanopub.PROV.wasAttributedTo, nanopub_author))
 
         if introduces_concept:
             # Convert introduces_concept URI to an rdflib term first (if necessary)

--- a/fairworkflows/nanopub.py
+++ b/fairworkflows/nanopub.py
@@ -229,7 +229,20 @@ class Nanopub:
         uri, _ = urldefrag(uri)
         this_np = rdflib.Namespace(uri+'#')
 
-        # Replace blank nodes with the nanopub's uri + a fragment derived from the blank node's name
+        # Replace any blank nodes in the supplied RDF, with a URI derived from the nanopub's uri.
+        # 'Blank nodes' here refers specifically to rdflib.term.BNode objects.
+        # For example, if the nanopub's URI is www.purl.org/ABC123 then the blank node will be replaced with a
+        # concrete URIRef of the form www.purl.org/ABC123#blanknodename where 'blanknodename' is the name of the
+        # the rdflib.term.BNode object. If blanknodename is 'step', then the URI will have a fragment '#step' after it.
+        # 
+        # The problem that this is designed to solve is that a user may wish to use the nanopublication to introduce
+        # a new concept. This new concept needs its own URI (it cannot simply be given the nanopublication's URI),
+        # but it should still lie within the space of the nanopub. Furthermore, the URI the nanopub is published
+        # is not known ahead of time. The variable 'this_np', for example, is holding a dummy URI that is swapped
+        # with the true, published URI of the nanopub by the 'np' tool at the moment of publication.
+        #
+        # We wish to replace any blank nodes in the rdf with URIs that are based on this same dummy URI, so that
+        # they too are transformed to the correct URI upon publishing.
         for s, p, o in assertionrdf:
             assertionrdf.remove((s, p, o))
             if isinstance(s, rdflib.term.BNode):

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -2,12 +2,11 @@ import warnings
 
 import rdflib
 
-
 class RdfWrapper:
-    def __init__(self, uri):
+    def __init__(self, uri, ref_name='fairobject'):
         self._rdf = rdflib.Graph()
         self._uri = uri
-        self.self_ref = rdflib.term.BNode('FairObject')
+        self.self_ref = rdflib.term.BNode(ref_name)
         self._is_modified = False
 
     @property

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -6,7 +6,7 @@ from .nanopub import Nanopub
 class RdfWrapper:
     def __init__(self, uri, ref_name='fairobject'):
         self._rdf = rdflib.Graph()
-        self._uri = uri
+        self._uri = str(uri)
         self.self_ref = rdflib.term.BNode(ref_name)
         self._is_modified = False
         self._is_published = False

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -7,7 +7,7 @@ class RdfWrapper:
     def __init__(self, uri):
         self._rdf = rdflib.Graph()
         self._uri = uri
-        self.self_ref = rdflib.URIRef(self._uri)
+        self.self_ref = rdflib.term.BNode('FairObject')
         self._is_modified = False
 
     @property
@@ -59,3 +59,15 @@ class RdfWrapper:
             self._rdf.remove((self.self_ref, predicate, None))
         self._rdf.add((self.self_ref, predicate, value))
         self._is_modified = True
+
+    def anonymise_rdf(self):
+        """
+        Replace any subjects or objects referring directly to the rdf uri, with a blank node
+        """
+        for s, p, o in self._rdf:
+            if self._uri == str(s):
+                self._rdf.remove((s, p, o))
+                self._rdf.add((self.self_ref, p, o))
+            if self._uri == str(o):
+                self._rdf.remove((s, p, o))
+                self._rdf.add((s, p, self.self_ref))

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -8,6 +8,7 @@ class RdfWrapper:
         self._rdf = rdflib.Graph()
         self._uri = uri
         self.self_ref = rdflib.URIRef(self._uri)
+        self._is_modified = False
 
     @property
     def rdf(self) -> rdflib.Graph:
@@ -18,6 +19,11 @@ class RdfWrapper:
     def uri(self) -> str:
         """Get the URI for this RDF."""
         return self._uri
+
+    @property
+    def is_modified(self) -> bool:
+        """Returns true if the RDF has been modified since initialisation"""
+        return self._is_modified
 
     def get_attribute(self, predicate):
         """Get attribute.
@@ -48,7 +54,8 @@ class RdfWrapper:
         it (but throw a warning).
         """
         if self.get_attribute(predicate) is not None:
-            warnings.warn(f'A predicate {predicate} was already defined'
-                          f'overwriting {predicate} for {self.self_ref}')
+            warnings.warn(f'A predicate {predicate} was already defined\n'
+                          f'Overwriting {predicate} for {self.self_ref}')
             self._rdf.remove((self.self_ref, predicate, None))
         self._rdf.add((self.self_ref, predicate, value))
+        self._is_modified = True

--- a/tests/resources/sample_fairstep_nanopub.trig
+++ b/tests/resources/sample_fairstep_nanopub.trig
@@ -1,0 +1,37 @@
+@prefix this: <http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg> .
+@prefix sub: <http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#> .
+@prefix bpmn: <http://dkm.fbk.eu/index.php/BPMN2_Ontology#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix p-plan: <http://purl.org/net/p-plan#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+sub:Head {
+  this: np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubInfo;
+    a np:Nanopublication .
+}
+
+sub:assertion {
+  sub:step dcterms:description "Preheat an oven to 350 degrees F (175 degrees C).";
+    a bpmn:ManualTask, p-plan:Step .
+}
+
+sub:provenance {
+  sub:assertion prov:generatedAtTime "2020-07-23T11:55:58.343358"^^xsd:dateTime;
+    prov:wasAttributedTo sub:experimentScientist .
+}
+
+sub:pubInfo {
+  sub:sig npx:hasAlgorithm "RSA";
+    npx:hasPublicKey "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCoZmUKAHAF0CY2sKahOanR1V8wP62NOw3G0wcVLULWxqXB/gcW25bGPcA5RKoiuhT6dUbfcRXmwLknE29h6KWfKYLtNaqdrHbjSnNC65dNmNxCNp0i6ZLZRh51mxw9IPJHZrDqQ9bcLwm9d1G1fDKasA+h1vrF3Hv1YrQsF9aW1QIDAQAB";
+    npx:hasSignature "hxNAxQb14SbdDtvPyyOurd4cG5/qWe5lb6cxrmRawDkzsF1VHguvwQ2VoAPQJ1lv3+kKhECuHO7LSB/Cip2S/36jtrllNIqn8HaDM2iWxXs0n9f8Gjkszprn0x7fjgh5w7zWw9/DQHjb29T/UGiG9bJABjaDgA3HOannLUy7Y1I=";
+    npx:hasSignatureTarget this: .
+  
+  this: npx:introduces sub:step;
+    prov:generatedAtTime "2020-07-23T11:55:58.343358"^^xsd:dateTime;
+    prov:wasAttributedTo <http://purl.org/person#DrBob> .
+}

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -120,3 +120,22 @@ def test_modification_and_republishing(nanopub_fetch_mock, nanopub_wrapper_publi
     assert preheat_oven.uri != original_uri
     assert preheat_oven.is_modified is False
 
+
+def test_anonymise_rdf():
+    """
+    Test that the anonymize_rdf() function is correctly replacing nodes
+    that contain the concept URI with the self_ref blank node.
+    """
+
+    test_uri = rdflib.URIRef('http://purl.org/sometest#step')
+
+    # Set up some basic rdf graph to intialise a FairStep with
+    rdf = rdflib.ConjunctiveGraph()
+    rdf.add( (test_uri, rdflib.DCTERMS.description, rdflib.term.Literal('Some step description')) )
+    step = FairStep(step_rdf=rdf, uri=test_uri)
+
+    # Check that the FairStep initialisation has anonymised this rdf
+    for s, p, o in step.rdf:
+        assert s is not test_uri
+        assert isinstance(s, rdflib.term.BNode)
+        assert s is step.self_ref

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -109,7 +109,8 @@ def test_modification_and_republishing(nanopub_fetch_mock, nanopub_wrapper_publi
     assert preheat_oven is not None
     assert not preheat_oven.is_modified
     original_uri = preheat_oven.uri
-    preheat_oven.publish_as_nanopub()
+    with pytest.warns(Warning):
+        preheat_oven.publish_as_nanopub()
     assert preheat_oven.uri == original_uri
 
     # Now modify the step description

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -106,4 +106,6 @@ def test_modification_and_republishing(nanopub_wrapper_publish_mock):
     preheat_oven.set_attribute(rdflib.DCTERMS.description, rdflib.term.Literal('Preheat an oven to 200 degrees C.'))
     assert preheat_oven.is_modified is True
     assert preheat_oven.publish_as_nanopub() is True
+    assert nanopub_wrapper_publish_mock.called
     assert preheat_oven.is_modified is False
+

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -100,12 +100,16 @@ def test_modification_and_republishing(nanopub_wrapper_publish_mock):
     preheat_oven = FairStep(uri='http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step', from_nanopub=True)
     assert preheat_oven is not None
     assert not preheat_oven.is_modified
-    assert preheat_oven.publish_as_nanopub() is False
+    original_uri = preheat_oven.uri
+    preheat_oven.publish_as_nanopub()
+    assert preheat_oven.uri == original_uri
 
     # Now modify the step description
     preheat_oven.description =  'Preheat an oven to 200 degrees C.'
     assert preheat_oven.is_modified is True
-    assert preheat_oven.publish_as_nanopub() is True
+    preheat_oven.publish_as_nanopub()
     assert nanopub_wrapper_publish_mock.called
+    assert preheat_oven.uri != original_uri
     assert preheat_oven.is_modified is False
+
 

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -48,6 +48,13 @@ class TestFairWorkflow:
         for i, step in enumerate(workflow_steps):
             assert step == right_order_steps[i]
 
+    @mock.patch('fairworkflows.nanopub_wrapper.publish')
+    def test_publish(self, nanopub_wrapper_publish_mock):
+        """
+        Test (mock) publishing of workflow
+        """
+        self.workflow.publish_as_nanopub()
+
     def test_decorator(self):
         workflow = FairWorkflow(description='This is a test workflow.')
 

--- a/tests/test_nanopub.py
+++ b/tests/test_nanopub.py
@@ -108,14 +108,14 @@ def test_nanopub_fetch():
 
 def test_nanopub_rdf():
     """
-    Test that Nanopub.rdf() is creating an rdf graph with the right features (contexts)
+    Test that Nanopub.to_rdf() is creating an rdf graph with the right features (contexts)
     for a nanopub.
     """
 
     assertionrdf = rdflib.Graph()
     assertionrdf.add((Nanopub.AUTHOR.DrBob, Nanopub.HYCL.claims, rdflib.Literal('This is a test')))
 
-    generated_rdf = Nanopub.rdf(assertionrdf)
+    generated_rdf = Nanopub.to_rdf(assertionrdf)
 
     assert generated_rdf is not None
     assert (None, RDF.type, Nanopub.NP.Nanopublication) in generated_rdf
@@ -124,7 +124,7 @@ def test_nanopub_rdf():
     assert (None, Nanopub.NP.hasPublicationInfo, None) in generated_rdf
 
     new_concept = rdflib.term.URIRef('www.purl.org/new/concept/test')
-    generated_rdf = Nanopub.rdf(assertionrdf, introduces_concept=new_concept)
+    generated_rdf = Nanopub.to_rdf(assertionrdf, introduces_concept=new_concept)
 
     assert generated_rdf is not None
     assert (None, RDF.type, Nanopub.NP.Nanopublication) in generated_rdf


### PR DESCRIPTION
Adds functionality to publish ```FairStep```s and ```FairWorkflow```s as nanopublications. If the RDF is already published (e.g. it was fetched from an existing nanopublication) then a new publication will not be created unless the rdf is modified in some way. If modified, the resulting nanopublication will refer to the original URI as prov:wasDerivedFrom in its prov subgraph.

Also now uses rdflib blank nodes to represent the root node of the step or plan. This blank node is automatically resolved to the new URI when republishing the (modified) rdf.