### PR TITLE
Add inputs and outputs to FairStep, validate FairWorkFlow based on inputs and outputs of steps.

### DIFF
--- a/fairworkflows/decorators.py
+++ b/fairworkflows/decorators.py
@@ -7,11 +7,11 @@ def fairstep(fw:FairWorkflow):
     given FairWorkflow, 'fw'
     """
 
-    def decorated_step(func):
+    def decorated_step(function):
 
         def wrapped_step(*args, **kwargs):
-            fw.add(FairStep.from_function(func=func))
-            func(*args, **kwargs)
+            fw.add(FairStep.from_function(function=function))
+            function(*args, **kwargs)
 
         return wrapped_step
 

--- a/fairworkflows/decorators.py
+++ b/fairworkflows/decorators.py
@@ -10,7 +10,7 @@ def fairstep(fw:FairWorkflow):
     def decorated_step(func):
 
         def wrapped_step(*args, **kwargs):
-            fw.add(FairStep(func=func))
+            fw.add(FairStep.from_function(func=func))
             func(*args, **kwargs)
 
         return wrapped_step

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -84,14 +84,14 @@ class FairStep(RdfWrapper):
         return self
 
     @classmethod
-    def from_function(cls, func):
+    def from_function(cls, function):
         """
             Generates a plex rdf decription for the given python function, and makes this FairStep object a bpmn:ScriptTask.
         """
-        name = func.__name__ + str(time.time())
+        name = function.__name__ + str(time.time())
         uri = 'http://purl.org/nanopub/temp/mynanopub#function' + name
         self = cls(uri=uri)
-        code = inspect.getsource(func)
+        code = inspect.getsource(function)
 
         # Set description of step to the raw function code
         self.description = code

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -1,4 +1,5 @@
 import inspect
+from typing import List
 from urllib.parse import urldefrag
 
 import rdflib
@@ -97,7 +98,7 @@ class FairStep(RdfWrapper):
         self.self_ref = rdflib.URIRef(self._uri)
 
         # Set description of step to the raw function code
-        self.description  = code
+        self.description = code
 
         # Specify that step is a pplan:Step
         self._rdf.add((self.self_ref, RDF.type, Nanopub.PPLAN.Step))
@@ -119,6 +120,24 @@ class FairStep(RdfWrapper):
     def is_script_task(self):
         """Returns True if this FairStep is a bpmn:ScriptTask, else False."""
         return (self.self_ref, RDF.type, Nanopub.BPMN.ScriptTask) in self._rdf
+
+    @property
+    def inputs(self) -> List[rdflib.URIRef]:
+        return self.get_attribute(Nanopub.PPLAN.hasInputVar)
+
+    @inputs.setter
+    def inputs(self, uris: List[str]):
+        for uri in uris:
+            self.set_attribute(Nanopub.PPLAN.hasInputVar, rdflib.URIRef(uri))
+
+    @property
+    def outputs(self) -> List[rdflib.URIRef]:
+        return self.get_attribute(Nanopub.PPLAN.hasOutputVar)
+
+    @outputs.setter
+    def outputs(self, uris: List[str]):
+        for uri in uris:
+            self.set_attribute(Nanopub.PPLAN.hasOutputVar, rdflib.URIRef(uri))
 
     @property
     def description(self):

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -12,12 +12,16 @@ from .rdf_wrapper import RdfWrapper
 
 
 class FairStep(RdfWrapper):
-    """
-        Class for building, validating and publishing Fair Steps, as described by the plex ontology in the publication:
+    """Represent a step in a fair workflow.
 
-        Celebi, R., Moreira, J. R., Hassan, A. A., Ayyar, S., Ridder, L., Kuhn, T., & Dumontier, M. (2019). Towards FAIR protocols and workflows: The OpenPREDICT case study. arXiv preprint arXiv:1911.09531.
+    Class for building, validating and publishing Fair Steps,
+    as described by the plex ontology in the publication:
+    Celebi, R., Moreira, J. R., Hassan, A. A., Ayyar, S., Ridder, L., Kuhn, T.,
+    & Dumontier, M. (2019). Towards FAIR protocols and workflows: T
+    he OpenPREDICT case study. arXiv preprint arXiv:1911.09531.
 
-        Fair Steps may be fetched from Nanopublications, or created from rdflib graphs or python functions.
+    Fair Steps may be fetched from Nanopublications, created from rdflib
+    graphs or python functions.
     """
 
     DEFAULT_STEP_URI = 'http://purl.org/nanopub/temp/mynanopub#step'

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -117,21 +117,27 @@ class FairStep(RdfWrapper):
 
     @property
     def inputs(self) -> List[rdflib.URIRef]:
-        return self.get_attribute(Nanopub.PPLAN.hasInputVar)
+        return self.get_attribute(Nanopub.PPLAN.hasInputVar,
+                                  always_return_list=True)
 
     @inputs.setter
     def inputs(self, uris: List[str]):
+        self.delete_attribute(Nanopub.PPLAN.hasInputVar)
         for uri in uris:
-            self.set_attribute(Nanopub.PPLAN.hasInputVar, rdflib.URIRef(uri))
+            self.set_attribute(Nanopub.PPLAN.hasInputVar, rdflib.URIRef(uri),
+                               overwrite=False)
 
     @property
     def outputs(self) -> List[rdflib.URIRef]:
-        return self.get_attribute(Nanopub.PPLAN.hasOutputVar)
+        return self.get_attribute(Nanopub.PPLAN.hasOutputVar,
+                                  always_return_list=True)
 
     @outputs.setter
     def outputs(self, uris: List[str]):
+        self.delete_attribute(Nanopub.PPLAN.hasOutputVar)
         for uri in uris:
-            self.set_attribute(Nanopub.PPLAN.hasOutputVar, rdflib.URIRef(uri))
+            self.set_attribute(Nanopub.PPLAN.hasOutputVar, rdflib.URIRef(uri),
+                               overwrite=False)
 
     @property
     def description(self):

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -117,11 +117,13 @@ class FairStep(RdfWrapper):
 
     @property
     def inputs(self) -> List[rdflib.URIRef]:
+        """Get inputs for this step."""
         return self.get_attribute(Nanopub.PPLAN.hasInputVar,
                                   always_return_list=True)
 
     @inputs.setter
     def inputs(self, uris: List[str]):
+        """Set inputs for this step. Overwrite old inputs."""
         self.delete_attribute(Nanopub.PPLAN.hasInputVar)
         for uri in uris:
             self.set_attribute(Nanopub.PPLAN.hasInputVar, rdflib.URIRef(uri),
@@ -129,11 +131,13 @@ class FairStep(RdfWrapper):
 
     @property
     def outputs(self) -> List[rdflib.URIRef]:
+        """Get inputs for this step."""
         return self.get_attribute(Nanopub.PPLAN.hasOutputVar,
                                   always_return_list=True)
 
     @outputs.setter
     def outputs(self, uris: List[str]):
+        """Set outputs for this step. Overwrite old inputs."""
         self.delete_attribute(Nanopub.PPLAN.hasOutputVar)
         for uri in uris:
             self.set_attribute(Nanopub.PPLAN.hasOutputVar, rdflib.URIRef(uri),

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -124,13 +124,18 @@ class FairStep(RdfWrapper):
 
     @property
     def inputs(self) -> List[rdflib.URIRef]:
-        """Get inputs for this step."""
+        """Inputs for this step.
+
+        Inputs are a list of URIRef's. The URIs should point to
+        a pplan.Variable, for example: www.purl.org/stepuri#inputvarname.
+        Set inputs by passing a list of strings depicting URIs. This
+        overwrites old inputs.
+        """
         return self.get_attribute(Nanopub.PPLAN.hasInputVar,
                                   always_return_list=True)
 
     @inputs.setter
     def inputs(self, uris: List[str]):
-        """Set inputs for this step. Overwrite old inputs."""
         self.delete_attribute(Nanopub.PPLAN.hasInputVar)
         for uri in uris:
             self.set_attribute(Nanopub.PPLAN.hasInputVar, rdflib.URIRef(uri),
@@ -138,13 +143,18 @@ class FairStep(RdfWrapper):
 
     @property
     def outputs(self) -> List[rdflib.URIRef]:
-        """Get inputs for this step."""
+        """Get inputs for this step.
+
+        Outputs are a list of URIRef's. The URIs should point to
+        a pplan.Variable, for example: www.purl.org/stepuri#outputvarname.
+        Set outputs by passing a list of strings depicting URIs. This
+        overwrites old outputs.
+        """
         return self.get_attribute(Nanopub.PPLAN.hasOutputVar,
                                   always_return_list=True)
 
     @outputs.setter
     def outputs(self, uris: List[str]):
-        """Set outputs for this step. Overwrite old inputs."""
         self.delete_attribute(Nanopub.PPLAN.hasOutputVar)
         for uri in uris:
             self.set_attribute(Nanopub.PPLAN.hasOutputVar, rdflib.URIRef(uri),

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -99,6 +99,7 @@ class FairWorkflow(RdfWrapper):
         else:
             self._rdf.add( (rdflib.URIRef(follows.uri), Nanopub.DUL.precedes, rdflib.URIRef(step.uri)) )
             self._steps[step.uri] = step
+            self._steps[follows.uri] = follows
             self._last_step_added = step
 
     def __iter__(self) -> Iterator[FairStep]:

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -176,7 +176,7 @@ class FairWorkflow(RdfWrapper):
             return graphviz
         except ImportError:
             raise ImportError('Cannot produce visualization of RDF, you need '
-                              'to install graphviz==0.14.1 python package. '
+                              'to install graphviz python package. '
                               'Version 0.14.1 is known to work well.')
 
     def display(self):

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -53,5 +53,13 @@ class RdfWrapper:
         if overwrite and self.get_attribute(predicate) is not None:
             warnings.warn(f'A predicate {predicate} was already defined'
                           f'overwriting {predicate} for {self.self_ref}')
-            self._rdf.remove((self.self_ref, predicate, None))
+            self.delete_attribute(predicate)
         self._rdf.add((self.self_ref, predicate, value))
+
+    def delete_attribute(self, predicate):
+        """Delete attribute.
+
+        Delete attribute of this RDF. I.e. remove all triples from the RDF for
+        the given `predicate` argument that have the self-reference subject.
+        """
+        self._rdf.remove((self.self_ref, predicate, None))

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -42,15 +42,15 @@ class RdfWrapper:
         else:
             return objects
 
-    def set_attribute(self, predicate, value):
+    def set_attribute(self, predicate, value, overwrite=True):
         """Set attribute.
 
         Set attribute of this RDF. I.e. for the given `predicate` argument, set
         the object to the given `value` argument for the subject
-        corresponding to this RDF. If the attribute already exists overwrite
-        it (but throw a warning).
+        corresponding to this RDF. Optionally overwrite the attribute if it
+        already exists (but throw a warning).
         """
-        if self.get_attribute(predicate) is not None:
+        if overwrite and self.get_attribute(predicate) is not None:
             warnings.warn(f'A predicate {predicate} was already defined'
                           f'overwriting {predicate} for {self.self_ref}')
             self._rdf.remove((self.self_ref, predicate, None))

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -19,7 +19,7 @@ class RdfWrapper:
         """Get the URI for this RDF."""
         return self._uri
 
-    def get_attribute(self, predicate):
+    def get_attribute(self, predicate, always_return_list=False):
         """Get attribute.
 
         Get attribute of this RDF.
@@ -32,6 +32,9 @@ class RdfWrapper:
         """
         objects = list(self._rdf.objects(subject=self.self_ref,
                                          predicate=predicate))
+        if always_return_list:
+            return objects
+
         if len(objects) == 0:
             return None
         elif len(objects) == 1:

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -16,8 +16,26 @@ def nanopub_server_unavailable():
 
 def test_fairstep_construction():
     step = FairStep()
-    step.inputs = ['http://test.org#input1']
-    step.outputs = ['http://test.org#output1']
+    step.inputs = ['test.org#input1', 'test.org#input2']
+    step.outputs = ['test.org#output1', 'test.org#output2']
+    assert len(step.inputs) == 2
+    assert len(step.outputs) == 2
+
+
+def test_fairstep_overwrite_inputs():
+    step = FairStep()
+    step.inputs = ['test.org#input1', 'test.org#input2']
+    assert len(step.inputs) == 2
+    step.inputs = ['test.org#input3']
+    assert len(step.inputs) == 1
+
+
+def test_fairstep_overwrite_outputs():
+    step = FairStep()
+    step.outputs = ['test.org#output1', 'test.org#output2']
+    assert len(step.outputs) == 2
+    step.outputs = ['test.org#output3']
+    assert len(step.outputs) == 1
 
 
 @pytest.mark.flaky(max_runs=10)

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -35,7 +35,7 @@ def test_fairstep_from_nanopub():
     ]
 
     for uri in nanopub_uris:
-        step = FairStep(uri=uri, from_nanopub=True)
+        step = FairStep.from_nanopub(uri=uri)
         assert step is not None
         step.validate()
         assert step.is_pplan_step
@@ -61,7 +61,7 @@ def test_fairstep_from_nanopub_without_fragment():
     ]
 
     for uri in nanopub_uris:
-        step = FairStep(uri=uri, from_nanopub=True)
+        step = FairStep.from_nanopub(uri=uri)
         assert step is not None
         step.validate()
         assert step.is_pplan_step
@@ -77,7 +77,7 @@ def test_fairstep_from_function():
         """
         return a + b
 
-    step = FairStep(func=add)
+    step = FairStep.from_function(func=add)
 
     assert step is not None
     step.validate()

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -7,10 +7,17 @@ BAD_GATEWAY = 502
 NANOPUB_SERVER = 'http://purl.org/np/'
 SERVER_UNAVAILABLE = 'Nanopub server is unavailable'
 
+
 def nanopub_server_unavailable():
     response = requests.get(NANOPUB_SERVER)
 
     return response.status_code == BAD_GATEWAY
+
+
+def test_fairstep_construction():
+    step = FairStep()
+    step.inputs = ['http://test.org#input1']
+    step.outputs = ['http://test.org#output1']
 
 
 @pytest.mark.flaky(max_runs=10)

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -91,7 +91,7 @@ class TestFairStep:
             """
             return a + b
 
-        step = FairStep.from_function(func=add)
+        step = FairStep.from_function(function=add)
 
         assert step is not None
         step.validate()

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -15,26 +15,30 @@ def nanopub_server_unavailable():
 
 
 class TestFairStep:
-    def test_construction(self):
+    def test_inputs_outputs(self):
+        test_inputs = ['test.org#input1', 'test.org#input2']
+        test_outputs = ['test.org#output1', 'test.org#output2']
         step = FairStep()
-        step.inputs = ['test.org#input1', 'test.org#input2']
-        step.outputs = ['test.org#output1', 'test.org#output2']
+        step.inputs = test_inputs
+        step.outputs = test_outputs
         assert len(step.inputs) == 2
         assert len(step.outputs) == 2
-    
-    def test_overwrite_inputs(self):
-        step = FairStep()
-        step.inputs = ['test.org#input1', 'test.org#input2']
-        assert len(step.inputs) == 2
-        step.inputs = ['test.org#input3']
-        assert len(step.inputs) == 1
+        for input in step.inputs:
+            assert str(input) in test_inputs
+        for output in step.outputs:
+            assert str(output) in test_outputs
 
-    def test_overwrite_outputs(self):
-        step = FairStep()
-        step.outputs = ['test.org#output1', 'test.org#output2']
-        assert len(step.outputs) == 2
-        step.outputs = ['test.org#output3']
+        # test overwriting
+        new_input = 'test.org#input3'
+        new_output = 'test.org#output3'
+        step.inputs = [new_input]
+        step.outputs = [new_output]
+        assert len(step.inputs) == 1
         assert len(step.outputs) == 1
+        for input in step.inputs:
+            assert str(input) == new_input
+        for output in step.outputs:
+            assert str(output) == new_output
 
     @pytest.mark.flaky(max_runs=10)
     @pytest.mark.skipif(nanopub_server_unavailable(), reason=SERVER_UNAVAILABLE)
@@ -54,8 +58,6 @@ class TestFairStep:
             step = FairStep.from_nanopub(uri=uri)
             assert step is not None
             step.validate()
-            assert step.is_pplan_step
-            assert step.description is not None
             assert step.is_manual_task
             assert not step.is_script_task
 
@@ -79,8 +81,6 @@ class TestFairStep:
             step = FairStep.from_nanopub(uri=uri)
             assert step is not None
             step.validate()
-            assert step.is_pplan_step
-            assert step.description is not None
             assert step.is_manual_task
             assert not step.is_script_task
 
@@ -95,8 +95,6 @@ class TestFairStep:
 
         assert step is not None
         step.validate()
-        assert step.is_pplan_step
-        assert step.description is not None
         assert not step.is_manual_task
         assert step.is_script_task
 

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -14,102 +14,97 @@ def nanopub_server_unavailable():
     return response.status_code == BAD_GATEWAY
 
 
-def test_fairstep_construction():
-    step = FairStep()
-    step.inputs = ['test.org#input1', 'test.org#input2']
-    step.outputs = ['test.org#output1', 'test.org#output2']
-    assert len(step.inputs) == 2
-    assert len(step.outputs) == 2
+class TestFairStep:
+    def test_construction(self):
+        step = FairStep()
+        step.inputs = ['test.org#input1', 'test.org#input2']
+        step.outputs = ['test.org#output1', 'test.org#output2']
+        assert len(step.inputs) == 2
+        assert len(step.outputs) == 2
+    
+    def test_overwrite_inputs(self):
+        step = FairStep()
+        step.inputs = ['test.org#input1', 'test.org#input2']
+        assert len(step.inputs) == 2
+        step.inputs = ['test.org#input3']
+        assert len(step.inputs) == 1
 
+    def test_overwrite_outputs(self):
+        step = FairStep()
+        step.outputs = ['test.org#output1', 'test.org#output2']
+        assert len(step.outputs) == 2
+        step.outputs = ['test.org#output3']
+        assert len(step.outputs) == 1
 
-def test_fairstep_overwrite_inputs():
-    step = FairStep()
-    step.inputs = ['test.org#input1', 'test.org#input2']
-    assert len(step.inputs) == 2
-    step.inputs = ['test.org#input3']
-    assert len(step.inputs) == 1
+    @pytest.mark.flaky(max_runs=10)
+    @pytest.mark.skipif(nanopub_server_unavailable(), reason=SERVER_UNAVAILABLE)
+    def test_construction_from_nanopub(self):
+        """
+            Check that we can load a FairStep from known nanopub URIs for manual steps,
+            that validation works, etc
+        """
 
+        nanopub_uris = [
+            'http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step',
+            'http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4#step',
+            'http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M#step'
+        ]
 
-def test_fairstep_overwrite_outputs():
-    step = FairStep()
-    step.outputs = ['test.org#output1', 'test.org#output2']
-    assert len(step.outputs) == 2
-    step.outputs = ['test.org#output3']
-    assert len(step.outputs) == 1
+        for uri in nanopub_uris:
+            step = FairStep.from_nanopub(uri=uri)
+            assert step is not None
+            step.validate()
+            assert step.is_pplan_step
+            assert step.description is not None
+            assert step.is_manual_task
+            assert not step.is_script_task
 
+    @pytest.mark.flaky(max_runs=10)
+    @pytest.mark.skipif(nanopub_server_unavailable(), reason=SERVER_UNAVAILABLE)
+    def test_construction_from_nanopub_without_fragment(self):
+        """
+            Check that we can load a FairStep from known nanopub URIs also
+            in cases where the full step URI is not used (i.e. missing a fragment).
+            In other words, only the nanopub URI is given, but not the URI of the
+            step itself within that nanopub.
+        """
 
-@pytest.mark.flaky(max_runs=10)
-@pytest.mark.skipif(nanopub_server_unavailable(), reason=SERVER_UNAVAILABLE)
-def test_fairstep_from_nanopub():
-    """
-        Check that we can load a FairStep from known nanopub URIs for manual steps,
-        that validation works, etc
-    """
+        nanopub_uris = [
+            'http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg',
+            'http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4',
+            'http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M'
+        ]
 
-    nanopub_uris = [
-        'http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step',
-        'http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4#step',
-        'http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M#step'
-    ]
+        for uri in nanopub_uris:
+            step = FairStep.from_nanopub(uri=uri)
+            assert step is not None
+            step.validate()
+            assert step.is_pplan_step
+            assert step.description is not None
+            assert step.is_manual_task
+            assert not step.is_script_task
 
-    for uri in nanopub_uris:
-        step = FairStep.from_nanopub(uri=uri)
+    def test_construction_from_function(self):
+        def add(a: int, b: int):
+            """
+            Computational step adding two ints together.
+            """
+            return a + b
+
+        step = FairStep.from_function(func=add)
+
         assert step is not None
         step.validate()
         assert step.is_pplan_step
         assert step.description is not None
-        assert step.is_manual_task
-        assert not step.is_script_task
+        assert not step.is_manual_task
+        assert step.is_script_task
 
+        assert step.__str__() is not None
+        assert len(step.__str__()) > 0
+        assert step.rdf is not None
 
-@pytest.mark.flaky(max_runs=10)
-@pytest.mark.skipif(nanopub_server_unavailable(), reason=SERVER_UNAVAILABLE)
-def test_fairstep_from_nanopub_without_fragment():
-    """
-        Check that we can load a FairStep from known nanopub URIs also
-        in cases where the full step URI is not used (i.e. missing a fragment).
-        In other words, only the nanopub URI is given, but not the URI of the
-        step itself within that nanopub.
-    """
-
-    nanopub_uris = [
-        'http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg',
-        'http://purl.org/np/RANBLu3UN2ngnjY5Hzrn7S5GpqFdz8_BBy92bDlt991X4',
-        'http://purl.org/np/RA5D8NzM2OXPZAWNlADQ8hZdVu1k0HnmVmgl20apjhU8M'
-    ]
-
-    for uri in nanopub_uris:
-        step = FairStep.from_nanopub(uri=uri)
-        assert step is not None
-        step.validate()
-        assert step.is_pplan_step
-        assert step.description is not None
-        assert step.is_manual_task
-        assert not step.is_script_task
-
-
-def test_fairstep_from_function():
-    def add(a: int, b: int):
-        """
-        Computational step adding two ints together.
-        """
-        return a + b
-
-    step = FairStep.from_function(func=add)
-
-    assert step is not None
-    step.validate()
-    assert step.is_pplan_step
-    assert step.description is not None
-    assert not step.is_manual_task
-    assert step.is_script_task
-
-    assert step.__str__() is not None
-    assert len(step.__str__()) > 0
-    assert step.rdf is not None
-
-
-def test_validation():
-    step = FairStep(uri='http://www.example.org/step')
-    with pytest.raises(AssertionError):
-        step.validate()
+    def test_validation(self):
+        step = FairStep(uri='http://www.example.org/step')
+        with pytest.raises(AssertionError):
+            step.validate()

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -48,6 +48,16 @@ class TestFairWorkflow:
         for i, step in enumerate(workflow_steps):
             assert step == right_order_steps[i]
 
+    def test_validate_inputs_outputs(self):
+        #
+        self.step1.outputs = ['var1']
+        self.step2.inputs = ['var1']
+        self.workflow.validate()
+        self.step1.inputs = ['var1']
+        self.step2.outputs = ['var1']
+        with pytest.raises(AssertionError):
+            self.workflow.validate()
+
     def test_decorator(self):
         workflow = FairWorkflow(description='This is a test workflow.')
 

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -60,6 +60,22 @@ class TestFairWorkflow:
         with pytest.raises(AssertionError):
             self.workflow.validate()
 
+    def test_unbound_inputs(self):
+        self.step1.inputs = ['var1']
+        self.step1.outputs = ['var2']
+        self.step2.inputs = ['var2', 'var3']
+        unbound_input_uris = [str(input) for input, step in
+                              self.workflow.unbound_inputs]
+        assert sorted(unbound_input_uris) == sorted(['var1', 'var3'])
+
+    def test_unbound_outputs(self):
+        self.step1.outputs = ['var1', 'var2']
+        self.step2.inputs = ['var2']
+        self.step2.outputs = ['var3']
+        unbound_output_uris = [str(output) for output, step in
+                               self.workflow.unbound_outputs]
+        assert sorted(unbound_output_uris) == sorted(['var1', 'var3'])
+
     def test_decorator(self):
         workflow = FairWorkflow(description='This is a test workflow.')
 

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -49,10 +49,12 @@ class TestFairWorkflow:
             assert step == right_order_steps[i]
 
     def test_validate_inputs_outputs(self):
-        #
+        # Step 1 precedes step 2, so valid if input of 2 is output of 1
         self.step1.outputs = ['var1']
         self.step2.inputs = ['var1']
         self.workflow.validate()
+
+        # Step 1 precedes step 2, so invalid if input of 1 is output of 2
         self.step1.inputs = ['var1']
         self.step2.outputs = ['var1']
         with pytest.raises(AssertionError):

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -64,11 +64,13 @@ class TestFairWorkflow:
         self.step1.inputs = ['var1']
         self.step1.outputs = ['var2']
         self.step2.inputs = ['var2', 'var3']
+        self.step2.outputs = []
         unbound_input_uris = [str(input) for input, step in
                               self.workflow.unbound_inputs]
         assert sorted(unbound_input_uris) == sorted(['var1', 'var3'])
 
     def test_unbound_outputs(self):
+        self.step1.inputs = []
         self.step1.outputs = ['var1', 'var2']
         self.step2.inputs = ['var2']
         self.step2.outputs = ['var3']


### PR DESCRIPTION
* Add `inputs` and `outputs` getters and setters to `FairStep`
* Add validation of step inputs and outputs with respect to `precedes` predicate of workflow
* Add `unbound_inputs` and `unbound_outputs`
* Refactor construction of `FairWorkflow` into separate classmethods.